### PR TITLE
Remove doubled slashes

### DIFF
--- a/docs-app/app/components/prose.gts
+++ b/docs-app/app/components/prose.gts
@@ -28,7 +28,7 @@ export const Prose: TOC<{ Element: HTMLDivElement }> = <template>
 
       <ExternalLink
         class="edit-page"
-        href="https://github.com/universal-ember/ember-primitives/edit/main/docs-app/public/docs/{{docs.selected.path}}.md"
+        href="https://github.com/universal-ember/ember-primitives/edit/main/docs-app/public/docs{{docs.selected.path}}.md"
       >
         Edit this page
       </ExternalLink>


### PR DESCRIPTION
This PR removes doubled slashes in links "Edit this page".

`.../public/docs//4-helpers/service.md`

`.../public/docs/4-helpers/service.md`

Doubled slashes break github browser cloning process.