### PR TITLE
[OTP Input]: add better correction behavior when using both mouse and keyboard

### DIFF
--- a/ember-primitives/src/components/one-time-password/input.gts
+++ b/ember-primitives/src/components/one-time-password/input.gts
@@ -4,7 +4,7 @@ import { isDestroyed, isDestroying } from '@ember/destroyable';
 import { on } from '@ember/modifier';
 import { buildWaiter } from '@ember/test-waiters';
 
-import { autoAdvance, getCollectiveValue, handleNavigation } from './utils';
+import { autoAdvance, getCollectiveValue, handleNavigation, selectAll } from './utils';
 
 import type { TOC } from '@ember/component/template-only';
 import type { WithBoundArgs } from '@glint/template';
@@ -40,6 +40,7 @@ const Fields: TOC<{
         type="text"
         inputmode="numeric"
         ...attributes
+        {{on "click" selectAll}}
         {{on "input" autoAdvance}}
         {{on "input" @handleChange}}
         {{on "keydown" handleNavigation}}

--- a/ember-primitives/src/components/one-time-password/utils.ts
+++ b/ember-primitives/src/components/one-time-password/utils.ts
@@ -15,6 +15,14 @@ function nextInput(current: HTMLInputElement) {
   return inputs[currentIndex + 1];
 }
 
+export function selectAll(event: Event) {
+  let target = event.target;
+
+  assert(`selectAll is only meant for use with input elements`, target instanceof HTMLInputElement);
+
+  target.select();
+}
+
 export function handleNavigation(event: KeyboardEvent) {
   switch (event.key) {
     case 'Backspace':

--- a/ember-primitives/src/components/one-time-password/utils.ts
+++ b/ember-primitives/src/components/one-time-password/utils.ts
@@ -42,7 +42,9 @@ function focusLeft(event: Pick<Event, 'target'>) {
   let input = previousInput(target);
 
   input?.focus();
-  input?.select();
+  requestAnimationFrame(() => {
+    input?.select();
+  });
 }
 
 function focusRight(event: Pick<Event, 'target'>) {
@@ -53,7 +55,9 @@ function focusRight(event: Pick<Event, 'target'>) {
   let input = nextInput(target);
 
   input?.focus();
-  input?.select();
+  requestAnimationFrame(() => {
+    input?.select();
+  });
 }
 
 function handleBackspace(event: KeyboardEvent) {


### PR DESCRIPTION
Resolves: https://github.com/universal-ember/ember-primitives/issues/229