### PR TITLE
[OTP] Trigger an input event for backspace

### DIFF
--- a/ember-primitives/src/components/one-time-password/utils.ts
+++ b/ember-primitives/src/components/one-time-password/utils.ts
@@ -121,6 +121,9 @@ function handleBackspace(event: KeyboardEvent) {
     target.value = '';
   }
 
+  const syntheticEvent = new InputEvent('input');
+  target?.dispatchEvent(syntheticEvent);
+
   focusLeft({ target });
 }
 

--- a/ember-primitives/src/components/one-time-password/utils.ts
+++ b/ember-primitives/src/components/one-time-password/utils.ts
@@ -104,6 +104,8 @@ function focusRight(event: Pick<Event, 'target'>) {
   });
 }
 
+const syntheticEvent = new InputEvent('input');
+
 function handleBackspace(event: KeyboardEvent) {
   if (event.key !== 'Backspace') return;
 
@@ -121,7 +123,6 @@ function handleBackspace(event: KeyboardEvent) {
     target.value = '';
   }
 
-  const syntheticEvent = new InputEvent('input');
   target?.dispatchEvent(syntheticEvent);
 
   focusLeft({ target });


### PR DESCRIPTION
Now that backspace uses `preventDefault` we need to manually trigger an input event

Closes #247