### PR TITLE
[OTP] makes backspace stay in current input unless it's empty

### DIFF
--- a/ember-primitives/src/components/one-time-password/utils.ts
+++ b/ember-primitives/src/components/one-time-password/utils.ts
@@ -120,12 +120,14 @@ function handleBackspace(event: KeyboardEvent) {
   let target = event.target;
 
   if (target && 'value' in target) {
-    target.value = '';
+    if (target.value === '') {
+      focusLeft({ target });
+    } else {
+      target.value = '';
+    }
   }
 
   target?.dispatchEvent(syntheticEvent);
-
-  focusLeft({ target });
 }
 
 function previousInput(current: HTMLInputElement) {


### PR DESCRIPTION
Closes #254 

Hitting backspace when the input has a value will keep the cursor inside the input.
Hitting backspace when the input has no value, will move the focus to the left.