### PR TITLE
Add Support for @activeOnSubPaths to Link component

### DIFF
--- a/ember-primitives/src/components/link.gts
+++ b/ember-primitives/src/components/link.gts
@@ -43,6 +43,35 @@ export interface Signature {
      *
      */
     includeActiveQueryParams?: true | string[];
+    /**
+     * When calculating the "active" state of the link, you may decide
+     * whether or not you want to consider sub paths to be active when
+     * child routes/urls are active.
+     *
+     * For example:
+     *
+     * ```gjs live preview
+     * import { Link } from 'ember-primitives';
+     *
+     * <template>
+     *   <Link @href="/forum/1" @activeOnSubPaths={{true}} as |a|>
+     *     ...
+     *   </Link>
+     * </template>
+     * ```
+     *
+     * the data-active state here will be "true" on
+     * - `/forum/1`
+     * - `/forum/1/posts`
+     * - `/forum/1/posts/comments`
+     * - `/forum/1/*etc*`
+     *
+     * if `@activeOnSubPaths` is set to false or left off
+     * the data-active state here will only be "true" on
+     * - `/forum/1`
+     *
+     */
+    activeOnSubPaths?: true;
   };
   Blocks: {
     default: [
@@ -103,6 +132,10 @@ export interface Signature {
          * configure the query params to be included if you wish
          * See: `@includeActiveQueryParams`
          *
+         * By default, only the exact route/url is considered for the `isActive` calculation,
+         * but you may configure sub routes/paths to also be considered active
+         * See: `@activeOnSubPaths`
+         *
          * Note that external links are never active.
          */
         isActive: boolean;
@@ -118,7 +151,7 @@ export interface Signature {
  * [mdn-a]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
  */
 export const Link: TOC<Signature> = <template>
-  {{#let (link @href includeActiveQueryParams=@includeActiveQueryParams) as |l|}}
+  {{#let (link @href includeActiveQueryParams=@includeActiveQueryParams activeOnSubPaths=@activeOnSubPaths) as |l|}}
     {{#if l.isExternal}}
       <ExternalLink href={{@href}} ...attributes>
         {{yield (hash isExternal=true isActive=false)}}

--- a/test-app/tests/link/rendering-test.gts
+++ b/test-app/tests/link/rendering-test.gts
@@ -202,6 +202,56 @@ module('<Link />', function (hooks) {
     assert.dom('[data-active]').hasText('One');
   });
 
+  test('[data-active] work with some params and activeOnSubPaths', async function (assert) {
+    setupRouting(this.owner, function () {
+      this.route('foo', function() {
+        this.route('bar')
+      });
+      this.route('bar');
+    });
+
+    this.owner.register(
+      'template:application',
+      hbs`
+      <Link id="one" @href="/foo?hello=2&there=3" @includeActiveQueryParams={{array "hello"}} @activeOnSubPaths={{true}} data-test-subpath>One</Link>
+      <Link id="one-child" @href="/foo/bar?hello=2&there=3" @includeActiveQueryParams={{array "hello"}} data-test-child>One Child</Link>
+      <Link id="two" @href="/foo?hello=1&there=3" @includeActiveQueryParams={{array "hello"}}>Two</Link>
+      <Link id="two-child" @href="/foo/bar?hello=1&there=3" @includeActiveQueryParams={{array "hello"}}>Two Child</Link>
+    `
+    );
+
+    await visit('/');
+
+    assert.dom('a').exists({ count: 4 });
+    assert.dom('[data-active]').exists({ count: 0 });
+
+    await click('#one');
+
+    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').hasText('One');
+
+    await click('#one-child');
+
+    assert.dom('[data-active]').exists({ count: 2 });
+    assert.dom('[data-active][data-test-child]').exists({ count: 1 });
+    assert.dom('[data-active][data-test-subpath]').exists({ count: 1 });
+
+    await click('#two');
+
+    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').hasText('Two');
+
+    await click('#two-child');
+
+    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').hasText('Two Child');
+
+    await click('#one');
+
+    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').hasText('One');
+  });
+
   test('[data-active] work with dynamic segments', async function (assert) {
     setupRouting(this.owner, function () {
       this.route('foo', { path: '/foo/:id' });

--- a/test-app/tests/link/rendering-test.gts
+++ b/test-app/tests/link/rendering-test.gts
@@ -204,8 +204,8 @@ module('<Link />', function (hooks) {
 
   test('[data-active] work with some params and activeOnSubPaths', async function (assert) {
     setupRouting(this.owner, function () {
-      this.route('foo', function() {
-        this.route('bar')
+      this.route('foo', function () {
+        this.route('bar');
       });
       this.route('bar');
     });

--- a/test-app/tests/link/rendering-test.gts
+++ b/test-app/tests/link/rendering-test.gts
@@ -58,33 +58,38 @@ module('<Link />', function (hooks) {
       <Link @href="/foo/a">a</Link>
       <Link @href="/foo/b">b</Link>
       <Link @href="/foo">Foo Home</Link>
+      <Link @href="/foo" @activeOnSubPaths={{true}} data-test-subpath>Foo Home Active On Subpaths</Link>
     `
     );
 
     await visit('/');
 
-    assert.dom('a').exists({ count: 3 });
+    assert.dom('a').exists({ count: 4 });
     assert.dom('[data-active]').exists({ count: 0 });
 
     await click('a[href="/foo"]');
 
-    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').exists({ count: 2 });
     assert.dom('[data-active]').hasText('Foo Home');
+    assert.dom('[data-test-subpath][data-active]').exists();
 
     await click('a[href="/foo/a"]');
 
-    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').exists({ count: 2 });
     assert.dom('[data-active]').hasText('a');
+    assert.dom('[data-test-subpath][data-active]').exists();
 
     await click('a[href="/foo/b"]');
 
-    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').exists({ count: 2 });
     assert.dom('[data-active]').hasText('b');
+    assert.dom('[data-test-subpath][data-active]').exists();
 
     await click('a[href="/foo"]');
 
-    assert.dom('[data-active]').exists({ count: 1 });
+    assert.dom('[data-active]').exists({ count: 2 });
     assert.dom('[data-active]').hasText('Foo Home');
+    assert.dom('[data-test-subpath][data-active]').exists();
   });
 
   test('[data-active] with a custom rootURL', async function (assert) {


### PR DESCRIPTION
Per #308 this adds a named arg `@activeOnSubPaths` to allow links to be considered `active` when child routes are the current URL.

The new `@activeOnSubPaths` arg defaults to false to retain existing active behavior without a breaking change. In a major release it may make sense to default this to true.