### PR TITLE
Support hash-only transitions in proper-links

### DIFF
--- a/docs-app/public/docs/4-routing/proper-links.md
+++ b/docs-app/public/docs/4-routing/proper-links.md
@@ -25,13 +25,14 @@ import `properLinks` and apply it to your Router.
 
 Once `@properLinks` is installed and setup, you can use plain `<a>` tags for navigation like this
 
-```gjs live preview 
+```gjs live preview
 <template>
-  <nav style="display: flex; gap: 0.5rem">
-    <a href="/">Home</a> 
-    <a href="/4-routing/link">Link docs</a> 
-    <a href="/4-routing/external-link">ExternalLink docs</a> 
-    <a href="https://developer.mozilla.org">MDN ➚</a> 
+  <nav id="example" style="display: flex; gap: 0.5rem">
+    <a href="/">Home</a>
+    <a href="#example">Link using a hash</a>
+    <a href="/4-routing/link">Link docs</a>
+    <a href="/4-routing/external-link">ExternalLink docs</a>
+    <a href="https://developer.mozilla.org">MDN ➚</a>
   </nav>
 </template>
 ```

--- a/ember-primitives/src/proper-links.ts
+++ b/ember-primitives/src/proper-links.ts
@@ -178,6 +178,20 @@ export function handle(
   if (location.origin !== url.origin) return;
 
   /**
+   * Hash-only links are handled by the browser, except for the case where the
+   * hash is being removed entirely, e.g. /foo#bar to /foo. In that case the
+   * browser will do a full page refresh which is not what we want. Instead
+   * we let the router handle such transitions. The current implementation of
+   * the Ember router will skip the transition in this case because the path
+   * is the same.
+   */
+  let [prehash, posthash] = url.href.split('#');
+
+  if (posthash !== undefined && prehash === location.href.split('#')[0]) {
+    return;
+  }
+
+  /**
    * We can optionally declare some paths as ignored,
    * or "let the browser do its default thing,
    * because there is other server-based routing to worry about"

--- a/ember-primitives/src/proper-links.ts
+++ b/ember-primitives/src/proper-links.ts
@@ -109,94 +109,11 @@ export function handle(
   ignore: string[],
   event: MouseEvent
 ) {
-  if (!element) return;
-  /**
-   * If we don't have an href, the <a> is invalid.
-   * If you're debugging your code and end up finding yourself
-   * early-returning here, please add an href ;)
-   */
-  if (!element.href) return;
-
-  /**
-   * This is partially an escape hatch, but any time target is set,
-   * we are usually wanting to escape the behavior of single-page-apps.
-   *
-   * Some folks desire to have in-SPA links, but still do native browser behavior
-   * (which for the case of SPAs is a full page refresh)
-   * but they can set target="_self" to get that behavior back if they want.
-   *
-   * I expect that this'll be a super edge case, because the whole goal of
-   * "proper links" is to do what is expected, always -- for in-app SPA links
-   * as well as external, cross-domain links
-   */
-  if (element.target) return;
-
-  /**
-   * If the click is not a "left click" we don't want to intercept the event.
-   * This allows folks to
-   * - middle click (usually open the link in a new tab)
-   * - right click (usually opens the context menu)
-   */
-  if (event.button !== 0) return;
-
-  /**
-   * for MacOS users, this default behavior opens the link in a new tab
-   */
-  if (event.metaKey) return;
-
-  /**
-   * for for everyone else, this default behavior opens the link in a new tab
-   */
-  if (event.ctrlKey) return;
-
-  /**
-   * The default behavior here downloads the link content
-   */
-  if (event.altKey) return;
-
-  /**
-   * The default behavior here opens the link in a new window
-   */
-  if (event.shiftKey) return;
-
-  /**
-   * If another event listener called event.preventDefault(), we don't want to proceed.
-   */
-  if (event.defaultPrevented) return;
-
-  /**
-   * The href includes the protocol/host/etc
-   * In order to not have the page look like a full page refresh,
-   * we need to chop that "origin" off, and just use the path
-   */
-  let url = new URL(element.href);
-
-  /**
-   * If the domains are different, we want to fall back to normal link behavior
-   *
-   */
-  if (location.origin !== url.origin) return;
-
-  /**
-   * Hash-only links are handled by the browser, except for the case where the
-   * hash is being removed entirely, e.g. /foo#bar to /foo. In that case the
-   * browser will do a full page refresh which is not what we want. Instead
-   * we let the router handle such transitions. The current implementation of
-   * the Ember router will skip the transition in this case because the path
-   * is the same.
-   */
-  let [prehash, posthash] = url.href.split('#');
-
-  if (posthash !== undefined && prehash === location.href.split('#')[0]) {
+  if (!shouldHandle(location.href, element, ignore, event)) {
     return;
   }
 
-  /**
-   * We can optionally declare some paths as ignored,
-   * or "let the browser do its default thing,
-   * because there is other server-based routing to worry about"
-   */
-  if (ignore.includes(url.pathname)) return;
+  let url = new URL(element.href);
 
   let fullHref = `${url.pathname}${url.search}${url.hash}`;
 
@@ -230,4 +147,107 @@ export function handle(
 
     throw e;
   }
+}
+
+/**
+ * Returns `true` if the link should be handled by the Ember router
+ * Returns `false` if the link should be handled by the browser
+ */
+export function shouldHandle(
+  href: string,
+  element: HTMLAnchorElement,
+  ignore: string[],
+  event: MouseEvent
+) {
+  if (!element) return false;
+  /**
+   * If we don't have an href, the <a> is invalid.
+   * If you're debugging your code and end up finding yourself
+   * early-returning here, please add an href ;)
+   */
+  if (!element.href) return false;
+
+  /**
+   * This is partially an escape hatch, but any time target is set,
+   * we are usually wanting to escape the behavior of single-page-apps.
+   *
+   * Some folks desire to have in-SPA links, but still do native browser behavior
+   * (which for the case of SPAs is a full page refresh)
+   * but they can set target="_self" to get that behavior back if they want.
+   *
+   * I expect that this'll be a super edge case, because the whole goal of
+   * "proper links" is to do what is expected, always -- for in-app SPA links
+   * as well as external, cross-domain links
+   */
+  if (element.target) return false;
+
+  /**
+   * If the click is not a "left click" we don't want to intercept the event.
+   * This allows folks to
+   * - middle click (usually open the link in a new tab)
+   * - right click (usually opens the context menu)
+   */
+  if (event.button !== 0) return false;
+
+  /**
+   * for MacOS users, this default behavior opens the link in a new tab
+   */
+  if (event.metaKey) return false;
+
+  /**
+   * for for everyone else, this default behavior opens the link in a new tab
+   */
+  if (event.ctrlKey) return false;
+
+  /**
+   * The default behavior here downloads the link content
+   */
+  if (event.altKey) return false;
+
+  /**
+   * The default behavior here opens the link in a new window
+   */
+  if (event.shiftKey) return false;
+
+  /**
+   * If another event listener called event.preventDefault(), we don't want to proceed.
+   */
+  if (event.defaultPrevented) return false;
+
+  /**
+   * The href includes the protocol/host/etc
+   * In order to not have the page look like a full page refresh,
+   * we need to chop that "origin" off, and just use the path
+   */
+  let url = new URL(element.href);
+  let location = new URL(href);
+
+  /**
+   * If the domains are different, we want to fall back to normal link behavior
+   *
+   */
+  if (location.origin !== url.origin) return false;
+
+  /**
+   * Hash-only links are handled by the browser, except for the case where the
+   * hash is being removed entirely, e.g. /foo#bar to /foo. In that case the
+   * browser will do a full page refresh which is not what we want. Instead
+   * we let the router handle such transitions. The current implementation of
+   * the Ember router will skip the transition in this case because the path
+   * is the same.
+   */
+  let [prehash, posthash] = url.href.split('#');
+
+  if (posthash !== undefined && prehash === location.href.split('#')[0]) {
+    return false;
+  }
+
+  /**
+   * We can optionally declare some paths as ignored,
+   * or "let the browser do its default thing,
+   * because there is other server-based routing to worry about"
+   */
+  if (ignore.includes(url.pathname)) return false;
+
+  return true;
 }

--- a/test-app/tests/proper-links/unit-test.ts
+++ b/test-app/tests/proper-links/unit-test.ts
@@ -1,0 +1,33 @@
+import { module, test } from 'qunit';
+
+import { shouldHandle } from 'ember-primitives/proper-links';
+
+module('@properLinks', function () {
+  module('shouldHandle', function () {
+    test('hash-only links', async function (assert) {
+      function assertShouldHandle(
+        expected: boolean,
+        { location, href }: { location: string; href: string }
+      ) {
+        let url = new URL(location, 'https://example.com');
+
+        let anchor = document.createElement('a');
+
+        anchor.href = new URL(href, url).href;
+
+        let ignored: string[] = [];
+        let simpleClickEvent = new MouseEvent('click');
+
+        assert.strictEqual(shouldHandle(url.href, anchor, ignored, simpleClickEvent), expected);
+      }
+
+      assertShouldHandle(false, { location: '/foo', href: '/foo#bar' });
+      assertShouldHandle(false, { location: '/foo', href: '#bar' });
+      assertShouldHandle(false, { location: '/foo#bar', href: '/foo#other' });
+
+      assertShouldHandle(true, { location: '/foo', href: '/abc#xyz' });
+      assertShouldHandle(true, { location: '/foo#bar', href: '/abc#xyz' });
+      assertShouldHandle(true, { location: '/foo#bar', href: '/foo' });
+    });
+  });
+});


### PR DESCRIPTION
This adds support for clicking hash-only links when using proper links.

The current behavior is that the click event is passed to the Ember router which essentially treats the transition as a no-op because the path is unchanged.

The new behavior is to allow the click event to be processed by the browser natively.

Here are some examples of where the default browser behavior is now used:

- Current location is `/foo` and clicking a link with href `/foo#bar`
- Current location is `/foo#bar` and clicking a link with href `/foo#other`
- Current location is `/foo` and clicking a link with href `#bar`.

Here are some examples where the Ember router is used instead:

- Current location is `/foo` and clicking a link with href `/abc#xyz`. Reason: the path has changed.
- Current location is `/foo#bar` and clicking a link with href `/abc#xyz`. Reason: the path has changed.
- Current location is `/foo#bar` and clicking a link with href `/foo`. Reason: the default browser behavior would cause a full page refresh in this scenario.

#### Testing

I wanted to add tests but I couldn't think of reasonable way to add them. One option was to architect the code a bit to allow the result of "was the event handled by the Ember router or by the browser" to be something interceptable/mockable. I didn't want to modify the code that much though. Alternatively, it could be tested with Playwright.