### PR TITLE
[Breaking] Document and solidify the public API of FloatingUI

### DIFF
--- a/docs-app/app/components/nav.gts
+++ b/docs-app/app/components/nav.gts
@@ -44,7 +44,7 @@ function nameFor(x: Page) {
     return `${x.componentName}`;
   }
 
-  return sentenceCase(x.name);
+  return x.title ? x.title : sentenceCase(x.name);
 }
 
 const asComponent = (str: string) => {

--- a/docs-app/app/components/nav.gts
+++ b/docs-app/app/components/nav.gts
@@ -10,6 +10,15 @@ import { getAnchor } from 'should-handle-link';
 import type { TOC } from '@ember/component/template-only';
 import type { DocsService, Page } from 'kolay';
 
+
+function fixWords(text: string) {
+  switch (text.toLowerCase()) {
+  case 'ui': return "UI";
+  case 'iframe': return 'IFrame';
+  default: return text;
+}
+}
+
 /**
  * Converts 1-2-hyphenated-thing
  * to
@@ -22,6 +31,7 @@ const titleize = (str: string) => {
       .filter(Boolean)
       .filter((text) => !text.match(/^[\d]+$/))
       .map((text) => `${text[0]?.toLocaleUpperCase()}${text.slice(1, text.length)}`)
+      .map((text) => fixWords(text))
       .join(' ')
       .split('.')[0] || ''
   );

--- a/docs-app/app/components/nav.gts
+++ b/docs-app/app/components/nav.gts
@@ -10,6 +10,10 @@ import { getAnchor } from 'should-handle-link';
 import type { TOC } from '@ember/component/template-only';
 import type { DocsService, Page } from 'kolay';
 
+type CustomPage = Page & {
+  title?: string;
+};
+
 function fixWords(text: string) {
   switch (text.toLowerCase()) {
     case 'ui':
@@ -40,13 +44,13 @@ const titleize = (str: string) => {
 };
 
 function nameFor(x: Page) {
-  // We defined componentName via json file
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   if ('componentName' in x) {
     return `${x.componentName}`;
   }
 
-  return x.title ? x.title : sentenceCase(x.name);
+  let page = x as CustomPage;
+
+  return page.title ? page.title : sentenceCase(page.name);
 }
 
 const asComponent = (str: string) => {

--- a/docs-app/app/components/nav.gts
+++ b/docs-app/app/components/nav.gts
@@ -10,13 +10,15 @@ import { getAnchor } from 'should-handle-link';
 import type { TOC } from '@ember/component/template-only';
 import type { DocsService, Page } from 'kolay';
 
-
 function fixWords(text: string) {
   switch (text.toLowerCase()) {
-  case 'ui': return "UI";
-  case 'iframe': return 'IFrame';
-  default: return text;
-}
+    case 'ui':
+      return 'UI';
+    case 'iframe':
+      return 'IFrame';
+    default:
+      return text;
+  }
 }
 
 /**

--- a/docs-app/app/routes/api-docs.gts
+++ b/docs-app/app/routes/api-docs.gts
@@ -1,4 +1,8 @@
-import { APIDocs as KolayAPIDocs, ComponentSignature as KolayComponentSignature } from 'kolay';
+import {
+  APIDocs as KolayAPIDocs,
+  ComponentSignature as KolayComponentSignature,
+  ModifierSignature as KolayModifierSignature,
+} from 'kolay';
 
 import type { TOC } from '@ember/component/template-only';
 
@@ -16,6 +20,16 @@ export const ComponentSignature: TOC<{
   Args: { declaration: string; name: string };
 }> = <template>
   <KolayComponentSignature
+    @package="ember-primitives"
+    @module="declarations/{{@declaration}}"
+    @name={{@name}}
+  />
+</template>;
+
+export const ModifierSignature: TOC<{
+  Args: { declaration: string; name: string };
+}> = <template>
+  <KolayModifierSignature
     @package="ember-primitives"
     @module="declarations/{{@declaration}}"
     @name={{@name}}

--- a/docs-app/app/routes/application.ts
+++ b/docs-app/app/routes/application.ts
@@ -6,7 +6,7 @@ import { Callout } from 'docs-app/components/callout';
 import { getHighlighterCore } from 'shiki/core';
 import getWasm from 'shiki/wasm';
 
-import { APIDocs, ComponentSignature } from './api-docs';
+import { APIDocs, ComponentSignature, ModifierSignature } from './api-docs';
 
 import type { SetupService } from 'ember-primitives';
 import type { DocsService } from 'kolay';
@@ -45,6 +45,7 @@ export default class Application extends Route {
         Callout,
         APIDocs,
         ComponentSignature,
+        ModifierSignature,
       },
       resolve: {
         // ember-primitives
@@ -65,6 +66,7 @@ export default class Application extends Route {
         // utility
         'lorem-ipsum': import('lorem-ipsum'),
         'form-data-utils': import('form-data-utils'),
+        kolay: import('kolay'),
       },
       rehypePlugins: [
         [

--- a/docs-app/public/docs/5-floaty-bits/floating-ui.md
+++ b/docs-app/public/docs/5-floaty-bits/floating-ui.md
@@ -18,7 +18,7 @@ pnpm add ember-primitives
 ```
 
 
-## `{{floatingUI}}`
+## `{{anchorTo}}`
 
 The main modifier for creating floating UIs with any elements.
 
@@ -28,11 +28,11 @@ Requires you to maintain a unique ID for every invocation.
 <div class="featured-demo">
 
 ```gjs live preview no-shadow
-import { floatingUI } from 'ember-primitives/floating-ui';
+import { anchorTo } from 'ember-primitives/floating-ui';
 
 <template>
   <button id="reference" popovertarget="floating">Click the reference element</button>
-  <menu popover id="floating" {{floatingUI "#reference"}}>Here is <br> floating element</menu>
+  <menu popover id="floating" {{anchorTo "#reference"}}>Here is <br> floating element</menu>
 
   <style>
     menu#floating {

--- a/docs-app/public/docs/5-floaty-bits/floating-ui.md
+++ b/docs-app/public/docs/5-floaty-bits/floating-ui.md
@@ -69,8 +69,9 @@ import { anchorTo } from 'ember-primitives/floating-ui';
 
 Note that in this demo thare are _two_ sets of ids. One pair for the floating behavior, and another pair for the [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) wiring.  The component below handles the floating id, but to avoid needing to maintain _unique_ pairs of ids for each floating-ui you may be interested in the [Popover](/5-floaty-bits/popover.md) component (which also includes arrow support).
 
+### API Reference for `{{anchorTo}}`
 
-```gjs no-shadow
+```gjs live no-shadow
 import { ModifierSignature } from 'kolay';
 
 <template>
@@ -81,6 +82,7 @@ import { ModifierSignature } from 'kolay';
   />
 </template>
 ```
+
 
 ## `<FloatingUI>`
 
@@ -133,6 +135,8 @@ import { FloatingUI } from 'ember-primitives/floating-ui';
 </div>
 
 Note that this demo has to main a unique id/target for the popover behavior. If you'd like to not have to manage ids at all, you may be interested in the [Popover](/5-floaty-bits/popover.md) component (which also includes arrow support).
+
+### API Reference for `<FloatingUI>`
 
 ```gjs live no-shadow
 import { ComponentSignature } from 'kolay';

--- a/docs-app/public/docs/5-floaty-bits/floating-ui.md
+++ b/docs-app/public/docs/5-floaty-bits/floating-ui.md
@@ -67,6 +67,8 @@ import { floatingUI } from 'ember-primitives/floating-ui';
 
 </div>
 
+Note that in this demo thare are _two_ sets of ids. One pair for the floating behavior, and another pair for the [popover](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/popover) wiring.  The component below handles the floating id, but to avoid needing to maintain _unique_ pairs of ids for each floating-ui you may be interested in the [Popover](/5-floaty-bits/popover.md) component (which also includes arrow support).
+
 
 ```gjs no-shadow
 import { ModifierSignature } from 'kolay';
@@ -129,6 +131,8 @@ import { FloatingUI } from 'ember-primitives/floating-ui';
 ```
 
 </div>
+
+Note that this demo has to main a unique id/target for the popover behavior. If you'd like to not have to manage ids at all, you may be interested in the [Popover](/5-floaty-bits/popover.md) component (which also includes arrow support).
 
 ```gjs live no-shadow
 import { ComponentSignature } from 'kolay';

--- a/docs-app/public/docs/5-floaty-bits/floating-ui.md
+++ b/docs-app/public/docs/5-floaty-bits/floating-ui.md
@@ -11,6 +11,12 @@ The usage of a 3rd-party library will be removed when [CSS Anchor Positioning](h
 Several of Floating UI's functions and [middleware](https://floating-ui.com/docs/middleware) are used to create an experience out of the box that is useful and expected.
 See Floating UI's [documentation](https://floating-ui.com/docs/getting-started) for more information on any of the following included functionality.
 
+## Setup
+
+```bash 
+pnpm add ember-primitives
+```
+
 
 ## `{{floatingUI}}`
 

--- a/docs-app/public/docs/5-floaty-bits/floating-ui.md
+++ b/docs-app/public/docs/5-floaty-bits/floating-ui.md
@@ -1,0 +1,152 @@
+# Floating UI
+
+The `FloatingUI` component (and modifier) provides a wrapper for using [Floating UI](https://floating-ui.com/), for associating a floating element to an anchor element (such as for menus, popovers, etc. 
+
+<Callout>
+
+The usage of a 3rd-party library will be removed when [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning) lands and is widely supported (This component and modifier will still exist for the purpose of wiring up the ids between anchor and target). 
+
+</Callout>
+
+Several of Floating UI's functions and [middleware](https://floating-ui.com/docs/middleware) are used to create an experience out of the box that is useful and expected.
+See Floating UI's [documentation](https://floating-ui.com/docs/getting-started) for more information on any of the following included functionality.
+
+
+## `{{floatingUI}}`
+
+The main modifier for creating floating UIs with any elements.
+
+Requires you to maintain a unique ID for every invocation. 
+
+
+<div class="featured-demo">
+
+```gjs live preview no-shadow
+import { floatingUI } from 'ember-primitives/floating-ui';
+
+<template>
+  <button id="reference" popovertarget="floating">Click the reference element</button>
+  <menu popover id="floating" {{floatingUI "#reference"}}>Here is <br> floating element</menu>
+
+  <style>
+    menu#floating {
+      width: max-content;
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: #222;
+      color: white;
+      font-weight: bold;
+      padding: 2rem;
+      border-radius: 4px;
+      font-size: 90%;
+      filter: drop-shadow(0 0 0.75rem rgba(0,0,0,0.4));
+      z-index: 10;
+    }
+    button#reference {
+      padding: 0.5rem;
+      border: 1px solid;
+      display: inline-block;
+      background: white;
+      color: black;
+      border-radius: 0.25rem;
+
+      &:hover {
+        background: #ddd;
+      }
+    }
+  </style>
+</template>
+```
+
+</div>
+
+
+```gjs no-shadow
+import { ModifierSignature } from 'kolay';
+
+<template>
+  <ModifierSignature 
+    @package="ember-primitives" 
+    @module="declarations/floating-ui/modifier" 
+    @name="Signature"
+  />
+</template>
+```
+
+## `<FloatingUI>`
+
+This component takes the above modifier and abstracts away the need to manage the `id`-relationship between reference and floating elements -- since every ID on the page needs to be unique, it is useful to have this automatically managed for you.
+
+This component has no DOM of its own, but provides two modifiers to attach to both reference and floating elements.
+
+<div class="featured-demo">
+
+```gjs live preview no-shadow
+import { FloatingUI } from 'ember-primitives/floating-ui';
+
+<template>
+  <FloatingUI as |reference floating|>
+    <button {{reference}} popovertarget="floating2">Click the reference element</button>
+    <menu {{floating}} popover id="floating2">Here is <br> floating element</menu>
+  </FloatingUI>
+
+  <style>
+    menu#floating2 {
+      width: max-content;
+      position: absolute;
+      top: 0;
+      left: 0;
+      background: #222;
+      color: white;
+      font-weight: bold;
+      padding: 2rem;
+      border-radius: 4px;
+      font-size: 90%;
+      filter: drop-shadow(0 0 0.75rem rgba(0,0,0,0.4));
+      z-index: 10;
+    }
+    button[popovertarget="floating2"] {
+      padding: 0.5rem;
+      border: 1px solid;
+      display: inline-block;
+      background: white;
+      color: black;
+      border-radius: 0.25rem;
+
+      &:hover {
+        background: #ddd;
+      }
+    }
+  </style>
+</template>
+```
+
+</div>
+
+```gjs live no-shadow
+import { ComponentSignature } from 'kolay';
+
+<template>
+  <ComponentSignature 
+    @package="ember-primitives" 
+    @module="declarations/floating-ui/component" 
+    @name="Signature" />
+</template>
+```
+
+## Comparison to similar projects
+
+Similar projects include:
+
+* [ember-popperjs](https://github.com/NullVoxPopuli/ember-popperjs)
+* [ember-popper-modifier](https://github.com/adopted-ember-addons/ember-popper-modifier)
+
+The above projects both use [Popper](https://popper.js.org/). In contrast, Ember Velcro uses Floating UI. Floating UI is the successor to Popper - see their [migration guide](https://floating-ui.com/docs/migration) for a complete comparison.
+
+There is also:
+
+* [ember-velcro](https://github.com/CrowdStrike/ember-velcro)
+
+which this project is a fork up, and ditches the velcro (hook / loop) verbiage and fixes bugs and improves ergonomics.
+

--- a/docs-app/public/docs/5-floaty-bits/popover.md
+++ b/docs-app/public/docs/5-floaty-bits/popover.md
@@ -124,7 +124,7 @@ const settings = cell(true);
                       things<br>
 
                       <Popover @placement="left" @offsetOptions={{16}} as |pp|>
-                        <button {{pp.hook}}>view profile</button>
+                        <button {{pp.reference}}>view profile</button>
 
                         <pp.Content class="floatybit">
                           View or edit your profile settings

--- a/docs-app/public/docs/5-floaty-bits/popover.md
+++ b/docs-app/public/docs/5-floaty-bits/popover.md
@@ -32,7 +32,7 @@ import { loremIpsum } from 'lorem-ipsum';
     {{loremIpsum (hash count=1 units="paragraphs")}}
 
     <Popover @placement="top" @offsetOptions={{8}} as |p|>
-      <div class="hook" {{p.hook}}>
+      <div class="hook" {{p.reference}}>
         the hook / anchor of the popover.
         <br> it sticks the boundary of this element.
       </div>
@@ -110,7 +110,7 @@ const settings = cell(true);
             <span>My App</span>
 
             <Popover @offsetOptions={{8}} as |p|>
-              <button class="hook" {{p.hook}} {{on 'click' settings.toggle}}>
+              <button class="hook" {{p.reference}} {{on 'click' settings.toggle}}>
                 Settings
               </button>
               {{#if settings.current}}

--- a/docs-app/public/docs/5-floaty-bits/popover.md
+++ b/docs-app/public/docs/5-floaty-bits/popover.md
@@ -1,19 +1,13 @@
 # Popover
 
-Popovers are built with [ember-velcro][gh-e-velcro], which is an ergonomic wrapper around [Floating UI][docs-floating], the successor to older (and more clunky) [Popper.JS][docs-popper]. 
+Popovers are built with [Floating UI][docs-floating-ui], a set of utilities for making floating elements relate to each other with minimal configuration. 
 
-
-<!--
-The goal of a popover is to provide additional behavioral functionality to make interacting with floaty bits easier:
-- focus trapping (TODO)
-- focus returning (TODO) 
--->
 
 The `<Popover>` component uses portals in a way that totally solves layering issues. No more worrying about tooltips on varying layers of your UI sometimes appearing behind other floaty bits. See the `<Portal>` and `<PortalTargets>` pages for more information.
 
 One thing to note is that the position of the popover can _escape_ the boundary of a [ShadowDom][docs-shadow-dom] -- all demos on this docs site for `ember-primitives` use a `ShadowDom` to allow for isolated CSS usage within the demos.
 
-[gh-e-velcro]: https://github.com/CrowdStrike/ember-velcro
+[docs-floating-ui]: /5-floaty-bits/floating-ui.md
 [docs-floating]: https://floating-ui.com/
 [docs-popper]: https://popper.js.org/
 [docs-shadow-dom]: https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_shadow_DOM

--- a/docs-app/public/docs/6-utils/data-from-event.json
+++ b/docs-app/public/docs/6-utils/data-from-event.json
@@ -1,0 +1,3 @@
+{
+  "title": "Data from Form Events 📦"
+}

--- a/docs-app/public/docs/6-utils/should-handle-link.json
+++ b/docs-app/public/docs/6-utils/should-handle-link.json
@@ -1,0 +1,3 @@
+{
+  "title": "Should Handle Link 📦"
+}

--- a/ember-primitives/src/components/menu.gts
+++ b/ember-primitives/src/components/menu.gts
@@ -39,7 +39,7 @@ export interface Signature {
         arrow: PopoverBlockParams['arrow'];
         trigger: WithBoundArgs<
           typeof trigger,
-          'triggerElement' | 'contentId' | 'isOpen' | 'setHook'
+          'triggerElement' | 'contentId' | 'isOpen' | 'setReference'
         >;
         Trigger: WithBoundArgs<typeof Trigger, 'triggerModifier'>;
         Content: WithBoundArgs<
@@ -187,7 +187,7 @@ interface PrivateTriggerModifierSignature {
       triggerElement: Cell<HTMLElement>;
       isOpen: Cell<boolean>;
       contentId: string;
-      setHook: PopoverBlockParams['setHook'];
+      setReference: PopoverBlockParams['setReference'];
     };
   };
 }
@@ -197,7 +197,7 @@ export interface TriggerModifierSignature {
 }
 
 const trigger = eModifier<PrivateTriggerModifierSignature>(
-  (element, _: [], { triggerElement, isOpen, contentId, setHook }) => {
+  (element, _: [], { triggerElement, isOpen, contentId, setReference }) => {
     element.setAttribute('aria-haspopup', 'menu');
 
     if (isOpen.current) {
@@ -215,7 +215,7 @@ const trigger = eModifier<PrivateTriggerModifierSignature>(
     element.addEventListener('click', onTriggerClick);
 
     triggerElement.current = element;
-    setHook(element);
+    setReference(element);
 
     return () => {
       element.removeEventListener('click', onTriggerClick);
@@ -228,7 +228,7 @@ interface PrivateTriggerSignature {
   Args: {
     triggerModifier: WithBoundArgs<
       typeof trigger,
-      'triggerElement' | 'contentId' | 'isOpen' | 'setHook'
+      'triggerElement' | 'contentId' | 'isOpen' | 'setReference'
     >;
   };
   Blocks: { default: [] };
@@ -270,7 +270,7 @@ export class Menu extends Component<Signature> {
             triggerElement=triggerEl
             isOpen=isOpen
             contentId=this.contentId
-            setHook=p.setHook
+            setReference=p.setReference
           )
           as |triggerModifier|
         }}

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -97,7 +97,7 @@ function getElementTag(tagName: undefined | string) {
 const Content: TOC<{
   Element: HTMLDivElement;
   Args: {
-    loop: ModifierLike<{ Element: HTMLElement }>;
+    floating: ModifierLike<{ Element: HTMLElement }>;
     inline?: boolean;
     /**
      * By default the popover content is wrapped in a div.
@@ -122,7 +122,7 @@ const Content: TOC<{
             https://github.com/tildeio/ember-element-helper/issues/91
             https://github.com/typed-ember/glint/issues/610
       }}
-      <El {{@loop}} ...attributes>
+      <El {{@floating}} ...attributes>
         {{yield}}
       </El>
     {{else}}
@@ -131,7 +131,7 @@ const Content: TOC<{
               https://github.com/tildeio/ember-element-helper/issues/91
               https://github.com/typed-ember/glint/issues/610
         }}
-        <El {{@loop}} ...attributes>
+        <El {{@floating}} ...attributes>
           {{yield}}
         </El>
       </Portal>
@@ -220,15 +220,15 @@ export const Popover: TOC<Signature> = <template>
       @flipOptions={{flipOptions @flipOptions}}
       @shiftOptions={{@shiftOptions}}
       @offsetOptions={{@offsetOptions}}
-      as |fui|
+      as |reference floating extra|
     >
       {{yield
         (hash
-          hook=fui.hook
-          setHook=fui.setHook
-          Content=(component Content loop=fui.loop inline=@inline)
-          data=fui.data
-          arrow=(modifier attachArrow arrowElement=arrowElement data=fui.data)
+          reference=reference
+          setHook=extra.setHook
+          Content=(component Content floating=floating inline=@inline)
+          data=extra.data
+          arrow=(modifier attachArrow arrowElement=arrowElement data=extra.data)
         )
       }}
     </FloatingUI>

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -20,19 +20,19 @@ export interface Signature {
     /**
      * See the Floating UI's [flip docs](https://floating-ui.com/docs/flip) for possible values.
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     flipOptions?: HookSignature['Args']['Named']['flipOptions'];
     /**
      * Array of one or more objects to add to Floating UI's list of [middleware](https://floating-ui.com/docs/middleware)
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     middleware?: HookSignature['Args']['Named']['middleware'];
     /**
      * See the Floating UI's [offset docs](https://floating-ui.com/docs/offset) for possible values.
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     offsetOptions?: HookSignature['Args']['Named']['offsetOptions'];
     /**
@@ -46,13 +46,13 @@ export interface Signature {
      *
      * And may optionally have `-start` or `-end` added to adjust position along the side.
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     placement?: `${'top' | 'bottom' | 'left' | 'right'}${'' | '-start' | '-end'}`;
     /**
      * See the Floating UI's [shift docs](https://floating-ui.com/docs/shift) for possible values.
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     shiftOptions?: HookSignature['Args']['Named']['shiftOptions'];
     /**
@@ -60,7 +60,7 @@ export interface Signature {
      *
      * Pros and cons of each strategy are explained on [Floating UI's Docs](https://floating-ui.com/docs/computePosition#strategy)
      *
-     * This argument is forwarded to `ember-velcro`'s `<Velcro>` component.
+     * This argument is forwarded to the `<FloatingUI>` component.
      */
     strategy?: HookSignature['Args']['Named']['strategy'];
 

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -76,10 +76,10 @@ export interface Signature {
   Blocks: {
     default: [
       {
-        hook: FloatingUiComponentSignature['Blocks']['default'][0]['hook'];
-        setHook: FloatingUiComponentSignature['Blocks']['default'][0]['setHook'];
-        Content: WithBoundArgs<typeof Content, 'loop'>;
-        data: FloatingUiComponentSignature['Blocks']['default'][0]['data'];
+        reference: FloatingUiComponentSignature['Blocks']['default'][0];
+        setReference: FloatingUiComponentSignature['Blocks']['default'][2]['setReference'];
+        Content: WithBoundArgs<typeof Content, 'floating'>;
+        data: FloatingUiComponentSignature['Blocks']['default'][2]['data'];
         arrow: WithBoundArgs<ModifierLike<AttachArrowSignature>, 'arrowElement' | 'data'>;
       },
     ];
@@ -225,7 +225,7 @@ export const Popover: TOC<Signature> = <template>
       {{yield
         (hash
           reference=reference
-          setHook=extra.setHook
+          setReference=extra.setReference
           Content=(component Content floating=floating inline=@inline)
           data=extra.data
           arrow=(modifier attachArrow arrowElement=arrowElement data=extra.data)

--- a/ember-primitives/src/floating-ui.ts
+++ b/ember-primitives/src/floating-ui.ts
@@ -1,2 +1,2 @@
-export { default as FloatingUI } from './floating-ui/component.gts';
+export { FloatingUI } from './floating-ui/component.gts';
 export { anchorTo } from './floating-ui/modifier.ts';

--- a/ember-primitives/src/floating-ui.ts
+++ b/ember-primitives/src/floating-ui.ts
@@ -1,2 +1,2 @@
 export { default as FloatingUI } from './floating-ui/component.gts';
-export { default as anchorTo } from './floating-ui/modifier.ts';
+export { AnchorTo as anchorTo } from './floating-ui/modifier.ts';

--- a/ember-primitives/src/floating-ui.ts
+++ b/ember-primitives/src/floating-ui.ts
@@ -1,2 +1,2 @@
 export { default as FloatingUI } from './floating-ui/component.gts';
-export { default as floatingUI } from './floating-ui/modifier.ts';
+export { default as anchorTo } from './floating-ui/modifier.ts';

--- a/ember-primitives/src/floating-ui.ts
+++ b/ember-primitives/src/floating-ui.ts
@@ -1,2 +1,2 @@
 export { default as FloatingUI } from './floating-ui/component.gts';
-export { AnchorTo as anchorTo } from './floating-ui/modifier.ts';
+export { anchorTo } from './floating-ui/modifier.ts';

--- a/ember-primitives/src/floating-ui/component.gts
+++ b/ember-primitives/src/floating-ui/component.gts
@@ -78,12 +78,15 @@ export default class Velcro extends Component<Signature> {
       as |loop|
     }}
       {{#let (if this.hook (modifier loop this.hook)) as |loopWithHook|}}
+        {{! reference }}
+        {{! floating}}
+        {{! extra }}
         {{! @glint-nocheck -- Excessively deep, possibly infinite }}
         {{yield
+          (modifier ref this.setHook)
+          loopWithHook
           (hash
-            hook=(modifier ref this.setHook)
             setHook=this.setHook
-            loop=loopWithHook
             data=this.velcroData
           )
         }}

--- a/ember-primitives/src/floating-ui/component.gts
+++ b/ember-primitives/src/floating-ui/component.gts
@@ -4,7 +4,7 @@ import { hash } from '@ember/helper';
 
 import { modifier as eModifier } from 'ember-modifier';
 
-import FloatingUIModifier from './modifier.ts';
+import { AnchorTo } from './modifier.ts';
 
 import type { Signature as ModifierSignature } from './modifier.ts';
 import type { MiddlewareState } from '@floating-ui/dom';
@@ -32,7 +32,7 @@ export interface Signature {
       reference: ModifierLike<ReferenceSignature>,
       floating:
         | undefined
-        | WithBoundArgs<WithBoundPositionals<typeof FloatingUIModifier, 1>, keyof ModifierArgs>,
+        | WithBoundArgs<WithBoundPositionals<typeof AnchorTo, 1>, keyof ModifierArgs>,
       util: {
         setReference: (element: HTMLElement | SVGElement) => void;
         data?: MiddlewareState;
@@ -58,7 +58,7 @@ export default class FloatingUI extends Component<Signature> {
   // set by VelcroModifier
   @tracked data?: MiddlewareState = undefined;
 
-  setData: ModifierArgs['setVelcroData'] = (data) => (this.data = data);
+  setData: ModifierArgs['setData'] = (data) => (this.data = data);
 
   setReference = (element: HTMLElement | SVGElement) => {
     this.reference = element;
@@ -67,7 +67,7 @@ export default class FloatingUI extends Component<Signature> {
   <template>
     {{#let
       (modifier
-        FloatingUIModifier
+        AnchorTo
         flipOptions=@flipOptions
         hideOptions=@hideOptions
         middleware=@middleware
@@ -75,11 +75,11 @@ export default class FloatingUI extends Component<Signature> {
         placement=@placement
         shiftOptions=@shiftOptions
         strategy=@strategy
-        setVelcroData=this.setData
+        setData=this.setData
       )
-      as |loop|
+      as |prewiredAnchorTo|
     }}
-      {{#let (if this.floating (modifier loop this.floating)) as |floating|}}
+      {{#let (if this.reference (modifier prewiredAnchorTo this.reference)) as |floating|}}
         {{! @glint-nocheck -- Excessively deep, possibly infinite }}
         {{yield
           (modifier ref this.setReference)

--- a/ember-primitives/src/floating-ui/component.gts
+++ b/ember-primitives/src/floating-ui/component.gts
@@ -4,7 +4,7 @@ import { hash } from '@ember/helper';
 
 import { modifier as eModifier } from 'ember-modifier';
 
-import { AnchorTo } from './modifier.ts';
+import { anchorTo } from './modifier.ts';
 
 import type { Signature as ModifierSignature } from './modifier.ts';
 import type { MiddlewareState } from '@floating-ui/dom';
@@ -32,7 +32,7 @@ export interface Signature {
       reference: ModifierLike<ReferenceSignature>,
       floating:
         | undefined
-        | WithBoundArgs<WithBoundPositionals<typeof AnchorTo, 1>, keyof ModifierArgs>,
+        | WithBoundArgs<WithBoundPositionals<typeof anchorTo, 1>, keyof ModifierArgs>,
       util: {
         setReference: (element: HTMLElement | SVGElement) => void;
         data?: MiddlewareState;
@@ -67,7 +67,7 @@ export default class FloatingUI extends Component<Signature> {
   <template>
     {{#let
       (modifier
-        AnchorTo
+        anchorTo
         flipOptions=@flipOptions
         hideOptions=@hideOptions
         middleware=@middleware

--- a/ember-primitives/src/floating-ui/component.gts
+++ b/ember-primitives/src/floating-ui/component.gts
@@ -19,22 +19,96 @@ interface ReferenceSignature {
 
 export interface Signature {
   Args: {
+    /**
+     * Additional middleware to pass to FloatingUI.
+     *
+     * See: [The middleware docs](https://floating-ui.com/docs/middleware)
+     */
     middleware?: ModifierArgs['middleware'];
+    /**
+     * Where to place the floating element relative to its reference element.
+     * The default is 'bottom'.
+     *
+     * See: [The placement docs](https://floating-ui.com/docs/computePosition#placement)
+     */
     placement?: ModifierArgs['placement'];
+    /**
+     * This is the type of CSS position property to use.
+     * By default this is 'fixed', but can also be 'absolute'.
+     *
+     * See: [The strategy docs](https://floating-ui.com/docs/computePosition#strategy)
+     */
     strategy?: ModifierArgs['strategy'];
+    /**
+     * Options to pass to the [flip middleware](https://floating-ui.com/docs/flip)
+     */
     flipOptions?: ModifierArgs['flipOptions'];
+    /**
+     * Options to pass to the [hide middleware](https://floating-ui.com/docs/hide)
+     */
     hideOptions?: ModifierArgs['hideOptions'];
+    /**
+     * Options to pass to the [shift middleware](https://floating-ui.com/docs/shift)
+     */
     shiftOptions?: ModifierArgs['shiftOptions'];
+    /**
+     * Options to pass to the [offset middleware](https://floating-ui.com/docs/offset)
+     */
     offsetOptions?: ModifierArgs['offsetOptions'];
   };
   Blocks: {
     default: [
+      /**
+       * A modifier to apply to the _reference_ element.
+       * This is what the floating element will use to anchor to.
+       *
+       * Example
+       * ```gjs
+       * import { FloatingUI } from 'ember-primitives/floating-ui';
+       *
+       * <template>
+       *   <FloatingUI as |reference floating|>
+       *     <button {{reference}}> ... </button>
+       *     ...
+       *   </FloatingUI>
+       * </template>
+       * ```
+       */
       reference: ModifierLike<ReferenceSignature>,
+      /**
+       * A modifier to apply to the _floating_ element.
+       * This is what will anchor to the reference element.
+       *
+       * Example
+       * ```gjs
+       * import { FloatingUI } from 'ember-primitives/floating-ui';
+       *
+       * <template>
+       *   <FloatingUI as |reference floating|>
+       *     <button {{reference}}> ... </button>
+       *     <menu {{floating}}> ... </menu>
+       *   </FloatingUI>
+       * </template>
+       * ```
+       */
       floating:
         | undefined
         | WithBoundArgs<WithBoundPositionals<typeof anchorTo, 1>, keyof ModifierArgs>,
+      /**
+       * Special utilities for advanced usage
+       */
       util: {
+        /**
+         * If you want to have a single modifier with custom behavior
+         * on your reference element, you may use this `setReference`
+         * function to set the reference, rather than having multiple modifiers
+         * on that element.
+         */
         setReference: (element: HTMLElement | SVGElement) => void;
+        /**
+         * Metadata exposed from floating-ui.
+         * Gives you x, y position, among other things.
+         */
         data?: MiddlewareState;
       },
     ];
@@ -52,10 +126,26 @@ const ref = eModifier<{
   fn(element);
 });
 
-export default class FloatingUI extends Component<Signature> {
+/**
+ * A component that provides no DOM and yields two modifiers for creating
+ * creating floating uis, such as menus, popovers, tooltips, etc.
+ * This component currently uses [Floating UI](https://floating-ui.com/)
+ * but will be switching to [CSS Anchor Positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_anchor_positioning) when that lands.
+ *
+ * Example usage:
+ * ```gjs
+ * import { FloatingUI } from 'ember-primitives/floating-ui';
+ *
+ * <template>
+ *   <FloatingUI as |reference floating|>
+ *     <button {{reference}}> ... </button>
+ *     <menu {{floating}}> ... </menu>
+ *   </FloatingUI>
+ * </template>
+ * ```
+ */
+export class FloatingUI extends Component<Signature> {
   @tracked reference?: HTMLElement | SVGElement = undefined;
-
-  // set by VelcroModifier
   @tracked data?: MiddlewareState = undefined;
 
   setData: ModifierArgs['setData'] = (data) => (this.data = data);

--- a/ember-primitives/src/floating-ui/component.gts
+++ b/ember-primitives/src/floating-ui/component.gts
@@ -30,7 +30,9 @@ export interface Signature {
   Blocks: {
     default: [
       reference: ModifierLike<ReferenceSignature>,
-      floating: undefined | WithBoundArgs<WithBoundPositionals<typeof FloatingUIModifier, 1>, keyof ModifierArgs>,
+      floating:
+        | undefined
+        | WithBoundArgs<WithBoundPositionals<typeof FloatingUIModifier, 1>, keyof ModifierArgs>,
       util: {
         setReference: (element: HTMLElement | SVGElement) => void;
         data?: MiddlewareState;
@@ -82,10 +84,7 @@ export default class FloatingUI extends Component<Signature> {
         {{yield
           (modifier ref this.setReference)
           floating
-          (hash
-            setReference=this.setReference
-            data=this.data
-          )
+          (hash setReference=this.setReference data=this.data)
         }}
       {{/let}}
     {{/let}}

--- a/ember-primitives/src/floating-ui/middleware.ts
+++ b/ember-primitives/src/floating-ui/middleware.ts
@@ -1,6 +1,6 @@
 import type { Middleware } from '@floating-ui/dom';
 
-export function velcroData(): Middleware {
+export function exposeMetadata(): Middleware {
   return {
     name: 'metadata',
     fn: (data) => {

--- a/ember-primitives/src/floating-ui/modifier.ts
+++ b/ember-primitives/src/floating-ui/modifier.ts
@@ -4,7 +4,7 @@ import { registerDestructor } from '@ember/destroyable';
 import { autoUpdate, computePosition, flip, hide, offset, shift } from '@floating-ui/dom';
 import Modifier from 'ember-modifier';
 
-import { velcroData } from './middleware.ts';
+import { exposeMetadata } from './middleware.ts';
 
 import type {
   FlipOptions,
@@ -28,12 +28,12 @@ export interface Signature {
       shiftOptions?: ShiftOptions;
       hideOptions?: HideOptions;
       middleware?: Middleware[];
-      setVelcroData?: Middleware['fn'];
+      setData?: Middleware['fn'];
     };
   };
 }
 
-export default class VelcroModifier extends Modifier<Signature> {
+export class AnchorTo extends Modifier<Signature> {
   modify(
     floatingElement: Signature['Element'],
     [_referenceElement]: Signature['Args']['Positional'],
@@ -44,7 +44,7 @@ export default class VelcroModifier extends Modifier<Signature> {
       flipOptions,
       shiftOptions,
       middleware = [],
-      setVelcroData,
+      setData: setData,
     }: Signature['Args']['Named']
   ) {
     const referenceElement: null | HTMLElement | SVGElement =
@@ -84,7 +84,7 @@ export default class VelcroModifier extends Modifier<Signature> {
           ...middleware,
           hide({ strategy: 'referenceHidden' }),
           hide({ strategy: 'escaped' }),
-          velcroData(),
+          exposeMetadata(),
         ],
         placement,
         strategy,
@@ -99,7 +99,7 @@ export default class VelcroModifier extends Modifier<Signature> {
         visibility: referenceHidden ? 'hidden' : 'visible',
       });
 
-      setVelcroData?.(middlewareData['metadata']);
+      setData?.(middlewareData['metadata']);
     };
 
     update();

--- a/ember-primitives/src/floating-ui/modifier.ts
+++ b/ember-primitives/src/floating-ui/modifier.ts
@@ -1,8 +1,7 @@
 import { assert } from '@ember/debug';
-import { registerDestructor } from '@ember/destroyable';
 
 import { autoUpdate, computePosition, flip, hide, offset, shift } from '@floating-ui/dom';
-import Modifier from 'ember-modifier';
+import { modifier as eModifier } from 'ember-modifier';
 
 import { exposeMetadata } from './middleware.ts';
 
@@ -33,10 +32,10 @@ export interface Signature {
   };
 }
 
-export class AnchorTo extends Modifier<Signature> {
-  modify(
-    floatingElement: Signature['Element'],
-    [_referenceElement]: Signature['Args']['Positional'],
+export const anchorTo = eModifier<Signature>(
+  (
+    floatingElement,
+    [_referenceElement],
     {
       strategy = 'fixed',
       offsetOptions = 0,
@@ -44,9 +43,9 @@ export class AnchorTo extends Modifier<Signature> {
       flipOptions,
       shiftOptions,
       middleware = [],
-      setData: setData,
-    }: Signature['Args']['Named']
-  ) {
+      setData,
+    }
+  ) => {
     const referenceElement: null | HTMLElement | SVGElement =
       typeof _referenceElement === 'string'
         ? document.querySelector(_referenceElement)
@@ -106,6 +105,6 @@ export class AnchorTo extends Modifier<Signature> {
 
     let cleanup = autoUpdate(referenceElement, floatingElement, update);
 
-    registerDestructor(this, cleanup);
+    return cleanup;
   }
-}
+);

--- a/ember-primitives/src/floating-ui/modifier.ts
+++ b/ember-primitives/src/floating-ui/modifier.ts
@@ -16,22 +16,88 @@ import type {
 } from '@floating-ui/dom';
 
 export interface Signature {
+  /**
+   *
+   */
   Element: HTMLElement;
   Args: {
-    Positional: [referenceElement: string | HTMLElement | SVGElement];
+    Positional: [
+      /**
+       * What do use as the reference element.
+       * Can be a selector or element instance.
+       *
+       * Example:
+       * ```gjs
+       * import { anchorTo } from 'ember-primitives/floating-ui';
+       *
+       * <template>
+       *   <div id="reference">...</div>
+       *   <div {{anchorTo "#reference"}}> ... </div>
+       * </template>
+       * ```
+       */
+      referenceElement: string | HTMLElement | SVGElement,
+    ];
     Named: {
+      /**
+       * This is the type of CSS position property to use.
+       * By default this is 'fixed', but can also be 'absolute'.
+       *
+       * See: [The strategy docs](https://floating-ui.com/docs/computePosition#strategy)
+       */
       strategy?: Strategy;
+      /**
+       * Options to pass to the [offset middleware](https://floating-ui.com/docs/offset)
+       */
       offsetOptions?: OffsetOptions;
+      /**
+       * Where to place the floating element relative to its reference element.
+       * The default is 'bottom'.
+       *
+       * See: [The placement docs](https://floating-ui.com/docs/computePosition#placement)
+       */
       placement?: Placement;
+      /**
+       * Options to pass to the [flip middleware](https://floating-ui.com/docs/flip)
+       */
       flipOptions?: FlipOptions;
+      /**
+       * Options to pass to the [shift middleware](https://floating-ui.com/docs/shift)
+       */
       shiftOptions?: ShiftOptions;
+      /**
+       * Options to pass to the [hide middleware](https://floating-ui.com/docs/hide)
+       */
       hideOptions?: HideOptions;
+      /**
+       * Additional middleware to pass to FloatingUI.
+       *
+       * See: [The middleware docs](https://floating-ui.com/docs/middleware)
+       */
       middleware?: Middleware[];
+      /**
+       * A callback for when data changes about the position / placement / etc
+       * of the floating element.
+       */
       setData?: Middleware['fn'];
     };
   };
 }
 
+/**
+ * A modifier to apply to the _floating_ element.
+ * This is what will anchor to the reference element.
+ *
+ * Example
+ * ```gjs
+ * import { anchorTo } from 'ember-primitives/floating-ui';
+ *
+ * <template>
+ *   <button id="my-button"> ... </button>
+ *   <menu {{anchorTo "#my-button"}}> ... </menu>
+ * </template>
+ * ```
+ */
 export const anchorTo = eModifier<Signature>(
   (
     floatingElement,

--- a/ember-primitives/src/floating-ui/modifier.ts
+++ b/ember-primitives/src/floating-ui/modifier.ts
@@ -105,6 +105,11 @@ export const anchorTo = eModifier<Signature>(
 
     let cleanup = autoUpdate(referenceElement, floatingElement, update);
 
+    /**
+     * in the function-modifier manager, teardown of the previous modifier
+     * occurs before setup of the next
+     * https://github.com/ember-modifier/ember-modifier/blob/main/ember-modifier/src/-private/function-based/modifier-manager.ts#L58
+     */
     return cleanup;
   }
 );

--- a/test-app/tests/floating-ui/component-main-test.gts
+++ b/test-app/tests/floating-ui/component-main-test.gts
@@ -7,7 +7,7 @@ import { FloatingUI } from 'ember-primitives/floating-ui';
 
 import { findElement, resetTestingContainerDimensions } from './test-helpers';
 
-module('Integration | Component | floating-ui', function (hooks) {
+module('floating-ui | component (main)', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/test-app/tests/floating-ui/component-main-test.gts
+++ b/test-app/tests/floating-ui/component-main-test.gts
@@ -40,20 +40,20 @@ module('Integration | Component | floating-ui', function (hooks) {
     });
   });
 
-  test('it renders with setHook', async function (assert) {
+  test('it renders with setReference', async function (assert) {
     let hookModifier = modifier(
       (
         element: HTMLElement | SVGElement,
-        [setHook]: [(element: HTMLElement | SVGElement) => void]
+        [setReference]: [(element: HTMLElement | SVGElement) => void]
       ) => {
-        setHook(element);
+        setReference(element);
       }
     );
 
     await render(
       <template>
         <FloatingUI as |velcro|>
-          <div id="hook" {{hookModifier velcro.setHook}} style="width: 200px; height: 40px">
+          <div id="hook" {{hookModifier velcro.setReference}} style="width: 200px; height: 40px">
             {{velcro.data.rects.reference.width}}
             {{velcro.data.rects.reference.height}}
           </div>

--- a/test-app/tests/floating-ui/component-main-test.gts
+++ b/test-app/tests/floating-ui/component-main-test.gts
@@ -17,14 +17,14 @@ module('Integration | Component | floating-ui', function (hooks) {
   test('it renders', async function (assert) {
     await render(
       <template>
-        <FloatingUI as |velcro|>
-          <div id="hook" {{velcro.hook}} style="width: 200px; height: 40px">
-            {{velcro.data.rects.reference.width}}
-            {{velcro.data.rects.reference.height}}
+        <FloatingUI as |reference floating util|>
+          <div id="hook" {{reference}} style="width: 200px; height: 40px">
+            {{util.data.rects.reference.width}}
+            {{util.data.rects.reference.height}}
           </div>
-          <div id="loop" {{velcro.loop}} style="width: 200px; height: 400px">
-            {{velcro.data.rects.floating.width}}
-            {{velcro.data.rects.floating.height}}
+          <div id="loop" {{floating}} style="width: 200px; height: 400px">
+            {{util.data.rects.floating.width}}
+            {{util.data.rects.floating.height}}
           </div>
         </FloatingUI>
       </template>
@@ -52,14 +52,14 @@ module('Integration | Component | floating-ui', function (hooks) {
 
     await render(
       <template>
-        <FloatingUI as |velcro|>
-          <div id="hook" {{hookModifier velcro.setReference}} style="width: 200px; height: 40px">
-            {{velcro.data.rects.reference.width}}
-            {{velcro.data.rects.reference.height}}
+        <FloatingUI as |reference floating util|>
+          <div id="hook" {{hookModifier util.setReference}} style="width: 200px; height: 40px">
+            {{util.data.rects.reference.width}}
+            {{util.data.rects.reference.height}}
           </div>
-          <div id="loop" {{velcro.loop}} style="width: 200px; height: 400px">
-            {{velcro.data.rects.floating.width}}
-            {{velcro.data.rects.floating.height}}
+          <div id="loop" {{floating}} style="width: 200px; height: 400px">
+            {{util.data.rects.floating.width}}
+            {{util.data.rects.floating.height}}
           </div>
         </FloatingUI>
       </template>
@@ -79,13 +79,13 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('it yields the MiddlewareState', async function (assert) {
       await render(
         <template>
-          <FloatingUI as |velcro|>
-            <div id="hook" {{velcro.hook}}>
-              {{#each-in velcro.data as |key|}}
+          <FloatingUI as |reference floating util|>
+            <div id="hook" {{reference}}>
+              {{#each-in util.data as |key|}}
                 {{key}}
               {{/each-in}}
             </div>
-            <div id="loop" {{velcro.loop}}>VelcroElement</div>
+            <div id="loop" {{floating}}>VelcroElement</div>
           </FloatingUI>
         </template>
       );
@@ -101,13 +101,13 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('it has expected included middleware defined', async function (assert) {
       await render(
         <template>
-          <FloatingUI as |velcro|>
-            <div id="hook" {{velcro.hook}}>
-              {{#each-in velcro.data.middlewareData as |key|}}
+          <FloatingUI as |reference floating util|>
+            <div id="hook" {{reference}}>
+              {{#each-in util.data.middlewareData as |key|}}
                 {{key}}
               {{/each-in}}
             </div>
-            <div id="loop" {{velcro.loop}}>VelcroElement</div>
+            <div id="loop" {{floating}}>VelcroElement</div>
           </FloatingUI>
         </template>
       );
@@ -120,9 +120,9 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('has default value', async function (assert) {
       await render(
         <template>
-          <FloatingUI as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="loop" {{velcro.loop}}>{{velcro.data.placement}}</div>
+          <FloatingUI as |reference floating util|>
+            <div {{reference}}>velcroReference</div>
+            <div id="loop" {{floating}}>{{util.data.placement}}</div>
           </FloatingUI>
         </template>
       );
@@ -133,9 +133,9 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('has argument value', async function (assert) {
       await render(
         <template>
-          <FloatingUI @placement="bottom-start" as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="loop" {{velcro.loop}}>{{velcro.data.placement}}</div>
+          <FloatingUI @placement="bottom-start" as |reference floating util|>
+            <div {{reference}}>velcroReference</div>
+            <div id="loop" {{floating}}>{{util.data.placement}}</div>
           </FloatingUI>
         </template>
       );
@@ -148,9 +148,9 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('has default value', async function (assert) {
       await render(
         <template>
-          <FloatingUI as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="loop" {{velcro.loop}}>{{velcro.data.strategy}}</div>
+          <FloatingUI as |reference floating util|>
+            <div {{reference}}>velcroReference</div>
+            <div id="loop" {{floating}}>{{util.data.strategy}}</div>
           </FloatingUI>
         </template>
       );
@@ -162,9 +162,9 @@ module('Integration | Component | floating-ui', function (hooks) {
     test('has argument value', async function (assert) {
       await render(
         <template>
-          <FloatingUI @strategy="absolute" as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="loop" {{velcro.loop}}>{{velcro.data.strategy}}</div>
+          <FloatingUI @strategy="absolute" as |reference floating util|>
+            <div {{reference}}>velcroReference</div>
+            <div id="loop" {{floating}}>{{util.data.strategy}}</div>
           </FloatingUI>
         </template>
       );
@@ -183,13 +183,17 @@ module('Integration | Component | floating-ui', function (hooks) {
           {{! render 2 Velcro's side by side, pass one a distance offset and compare the top values }}
           {{! template-lint-disable no-inline-styles }}
           <div style="display: flex">
-            <FloatingUI @placement="bottom-start" as |velcro|>
-              <div {{velcro.hook}}>velcroReference</div>
-              <div id="velcro1" {{velcro.loop}}>Velcro</div>
+            <FloatingUI @placement="bottom-start" as |reference floating|>
+              <div {{reference}}>velcroReference</div>
+              <div id="velcro1" {{floating}}>Velcro</div>
             </FloatingUI>
-            <FloatingUI @offsetOptions={{offsetDistance}} @placement="bottom-start" as |velcro|>
-              <div {{velcro.hook}}>velcroReference</div>
-              <div id="velcro2" {{velcro.loop}}>Velcro</div>
+            <FloatingUI
+              @offsetOptions={{offsetDistance}}
+              @placement="bottom-start"
+              as |reference floating|
+            >
+              <div {{reference}}>velcroReference</div>
+              <div id="velcro2" {{floating}}>Velcro</div>
             </FloatingUI>
           </div>
         </template>
@@ -212,13 +216,13 @@ module('Integration | Component | floating-ui', function (hooks) {
       await render(
         <template>
           {{! render 2 Velcro's atop the other, pass one a skidding offset and compare the left values }}
-          <FloatingUI as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="velcro1" {{velcro.loop}}>Velcro</div>
+          <FloatingUI as |reference floating|>
+            <div {{reference}}>velcroReference</div>
+            <div id="velcro1" {{floating}}>Velcro</div>
           </FloatingUI>
-          <FloatingUI @offsetOptions={{offsetOptions}} as |velcro|>
-            <div {{velcro.hook}}>velcroReference</div>
-            <div id="velcro2" {{velcro.loop}}>Velcro</div>
+          <FloatingUI @offsetOptions={{offsetOptions}} as |reference floating|>
+            <div {{reference}}>velcroReference</div>
+            <div id="velcro2" {{floating}}>Velcro</div>
           </FloatingUI>
         </template>
       );

--- a/test-app/tests/floating-ui/component-test.gts
+++ b/test-app/tests/floating-ui/component-test.gts
@@ -6,7 +6,7 @@ import { FloatingUI } from 'ember-primitives/floating-ui';
 
 import { resetTestingContainerDimensions } from './test-helpers';
 
-module('Integration | Component | floating-ui (strict mode)', function (hooks) {
+module('floating-ui (strict mode)', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/test-app/tests/floating-ui/component-test.gts
+++ b/test-app/tests/floating-ui/component-test.gts
@@ -16,14 +16,14 @@ module('Integration | Component | floating-ui (strict mode)', function (hooks) {
   test('it renders', async function (assert) {
     await render(
       <template>
-        <FloatingUI as |velcro|>
-          <div id="hook" {{velcro.hook}} style="width: 200px; height: 40px">
-            {{velcro.data.rects.reference.width}}
-            {{velcro.data.rects.reference.height}}
+        <FloatingUI as |reference floating util|>
+          <div id="hook" {{reference}} style="width: 200px; height: 40px">
+            {{util.data.rects.reference.width}}
+            {{util.data.rects.reference.height}}
           </div>
-          <div id="loop" {{velcro.loop}} style="width: 200px; height: 400px">
-            {{velcro.data.rects.floating.width}}
-            {{velcro.data.rects.floating.height}}
+          <div id="loop" {{floating}} style="width: 200px; height: 400px">
+            {{util.data.rects.floating.width}}
+            {{util.data.rects.floating.height}}
           </div>
         </FloatingUI>
       </template>

--- a/test-app/tests/floating-ui/modifier-test.gts
+++ b/test-app/tests/floating-ui/modifier-test.gts
@@ -6,7 +6,7 @@ import { anchorTo } from 'ember-primitives/floating-ui';
 
 import { addDataAttributes, findElement, resetTestingContainerDimensions } from './test-helpers';
 
-module('Integration | Modifier | anchorTo', function (hooks) {
+module('floating-ui | anchorTo', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {

--- a/test-app/tests/floating-ui/modifier-test.gts
+++ b/test-app/tests/floating-ui/modifier-test.gts
@@ -2,11 +2,11 @@ import { render } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { floatingUI } from 'ember-primitives/floating-ui';
+import { anchorTo } from 'ember-primitives/floating-ui';
 
 import { addDataAttributes, findElement, resetTestingContainerDimensions } from './test-helpers';
 
-module('Integration | Modifier | floatingUI', function (hooks) {
+module('Integration | Modifier | anchorTo', function (hooks) {
   setupRenderingTest(hooks);
 
   hooks.beforeEach(function () {
@@ -17,7 +17,7 @@ module('Integration | Modifier | floatingUI', function (hooks) {
     await render(
       <template>
         <div id="reference">Reference</div>
-        <div {{floatingUI "#reference"}}></div>
+        <div {{anchorTo "#reference"}}></div>
       </template>
     );
 
@@ -31,7 +31,7 @@ module('Integration | Modifier | floatingUI', function (hooks) {
       await render(
         <template>
           <div id="velcro-reference">Velcro reference</div>
-          <div id="velcro" {{floatingUI "#velcro-reference" middleware=middleware}}>Velcro</div>
+          <div id="velcro" {{anchorTo "#velcro-reference" middleware=middleware}}>Velcro</div>
         </template>
       );
 
@@ -44,7 +44,7 @@ module('Integration | Modifier | floatingUI', function (hooks) {
           <div id="velcro-reference">Velcro reference</div>
           <div
             id="velcro"
-            {{floatingUI "#velcro-reference" placement="bottom-start" middleware=middleware}}
+            {{anchorTo "#velcro-reference" placement="bottom-start" middleware=middleware}}
           >Velcro</div>
         </template>
       );
@@ -60,7 +60,7 @@ module('Integration | Modifier | floatingUI', function (hooks) {
       await render(
         <template>
           <div id="velcro-reference">Velcro reference</div>
-          <div id="velcro" {{floatingUI "#velcro-reference" middleware=middleware}}>Velcro</div>
+          <div id="velcro" {{anchorTo "#velcro-reference" middleware=middleware}}>Velcro</div>
         </template>
       );
 
@@ -73,7 +73,7 @@ module('Integration | Modifier | floatingUI', function (hooks) {
           <div id="velcro-reference">Velcro reference</div>
           <div
             id="velcro"
-            {{floatingUI "#velcro-reference" strategy="absolute" middleware=middleware}}
+            {{anchorTo "#velcro-reference" strategy="absolute" middleware=middleware}}
           >Velcro</div>
         </template>
       );
@@ -93,13 +93,13 @@ module('Integration | Modifier | floatingUI', function (hooks) {
           <div style="display: flex">
             <div>
               <div id="velcro-reference">Velcro reference</div>
-              <div id="velcro1" {{floatingUI "#velcro-reference"}}>Velcro</div>
+              <div id="velcro1" {{anchorTo "#velcro-reference"}}>Velcro</div>
             </div>
             <div>
               <div>velcroReference</div>
               <div
                 id="velcro2"
-                {{floatingUI
+                {{anchorTo
                   "#velcro-reference"
                   offsetOptions=offsetDistance
                   placement="bottom-start"
@@ -129,13 +129,13 @@ module('Integration | Modifier | floatingUI', function (hooks) {
           {{! render 2 Velcro's atop the other, pass one a skidding offset and compare the left values }}
           <div>
             <div id="velcro-reference">Velcro reference</div>
-            <div id="velcro1" {{floatingUI "#velcro-reference"}}>Velcro</div>
+            <div id="velcro1" {{anchorTo "#velcro-reference"}}>Velcro</div>
           </div>
           <div>
             <div id="velcro-reference2">velcroReference</div>
             <div
               id="velcro2"
-              {{floatingUI "#velcro-reference2" offsetOptions=offsetOptions}}
+              {{anchorTo "#velcro-reference2" offsetOptions=offsetOptions}}
             >Velcro</div>
           </div>
         </template>


### PR DESCRIPTION
Resolves: 
- https://github.com/CrowdStrike/ember-velcro/issues/149
- https://github.com/universal-ember/ember-primitives/issues/378

What:
- Moves away from velcro terminology that folks might not be familiar with if they've never looked super close at how velcro works
- Optimizes for the common case of only using a `{{reference}}` and `{{floating}}` modifier
- The modifier-only usage has been renamed to `{{anchorTo}}`
  ```hbs
  <button id="#reference"> ... </button>
  <menu {{anchorTo "#reference"}}> ... </menu>
  ```
- Terms used for `Popover` have also changed to reflect the move away from "velcro"

Documentation:
- New page for Floating UI
  - Component usage
  - modifier usage
    - passing Selector
    - passing element
- Updates to the sidebar