### PR TITLE
Add focusOnClose modifier for the modal button

### DIFF
--- a/docs-app/public/docs/5-floaty-bits/modal.md
+++ b/docs-app/public/docs/5-floaty-bits/modal.md
@@ -20,7 +20,7 @@ const returnValue = cell('');
 
 <template>
   <Modal @onClose={{returnValue.set}} as |m|>
-    <button {{on 'click' m.open}}>Open Modal</button>
+    <button {{on 'click' m.open}} {{m.focusOnClose}}>Open Modal</button>
 
     <br><br>
     isOpen: {{m.isOpen}}<br>

--- a/docs-app/public/docs/5-floaty-bits/modal.md
+++ b/docs-app/public/docs/5-floaty-bits/modal.md
@@ -315,6 +315,8 @@ The dialog element handles ESC (escape) key events automatically, hence reducing
 
 However, if you want to add an animation effect on _closing_ and opening dialog programmatically, note that you will lose this built-in feature support and have to implement the tab navigation focus yourself.
 
+When the dialog is closed, you can refocus the opening button when the `{{m.focusOnClose}}` modifier is applied to that button.
+
 
 ## References
 

--- a/ember-primitives/src/components/dialog.gts
+++ b/ember-primitives/src/components/dialog.gts
@@ -14,8 +14,6 @@ import { localCopy } from "tracked-toolbox";
 import type { TOC } from "@ember/component/template-only";
 import type { ModifierLike, WithBoundArgs } from "@glint/template";
 
-const not = (x: boolean | undefined): boolean => !x;
-
 const DialogElement: TOC<{
   Element: HTMLDialogElement;
   Args: {
@@ -35,7 +33,7 @@ const DialogElement: TOC<{
   };
   Blocks: { default: [] };
 }> = <template>
-  <dialog ...attributes inert={{not @open}} open={{@open}} {{on "close" @onClose}} {{@register}}>
+  <dialog ...attributes open={{@open}} {{on "close" @onClose}} {{@register}}>
     {{yield}}
   </dialog>
 </template>;

--- a/ember-primitives/src/components/dialog.gts
+++ b/ember-primitives/src/components/dialog.gts
@@ -98,9 +98,6 @@ export interface Signature {
         /**
          * This is the `<dialog>` element (with some defaults pre-wired).
          * This is required to be rendered.
-         *
-         * The underlying `<dialog>` element is declared `inert` when closed to prevent accidental focus/outline
-         * highlighting for keyboard users.
          */
         Dialog: WithBoundArgs<typeof DialogElement, "onClose" | "register" | "open">;
       },


### PR DESCRIPTION
When closing a modal, the button than opened the modal should be focused.

This is opt-in behavior via the `{{m.focusOnClose}}` modifier