### PR TITLE
Make `<Shadowed>` sync (no more modifier, no more reactive need) | Also add test utilities for working with shadow roots

### DIFF
--- a/ember-primitives/src/components/shadowed.gts
+++ b/ember-primitives/src/components/shadowed.gts
@@ -1,32 +1,6 @@
-import { modifier } from "ember-modifier";
-import { cell } from "ember-resources";
+import Component from "@glimmer/component";
 
-import type { TOC } from "@ember/component/template-only";
-
-const Shadow = () => {
-  const shadow = cell<Element>();
-
-  return {
-    get root() {
-      return shadow.current;
-    },
-    attach: modifier((element: Element) => {
-      const shadowRoot = element.attachShadow({ mode: "open" });
-      const div = document.createElement("div");
-
-      // ember-source 5.6 broke the ability to in-element
-      // natively into a shadowroot.
-      //
-      // See these ember-source bugs:
-      // - https://github.com/emberjs/ember.js/issues/20643
-      // - https://github.com/emberjs/ember.js/issues/20642
-      // - https://github.com/emberjs/ember.js/issues/20641
-      shadowRoot.appendChild(div);
-
-      shadow.set(div);
-    }),
-  };
-};
+import type Owner from "@ember/owner";
 
 // index.html has the production-fingerprinted references to these links
 // Ideally, we'd have some pre-processor scan everything for references to
@@ -58,7 +32,7 @@ const Styles = <template>
  *
  * This is useful when you want to render content that escapes your app's styles.
  */
-export const Shadowed: TOC<{
+export class Shadowed extends Component<{
   /**
    * The shadow dom attaches to a div element.
    * You may specify any attribute, and it'll be applied to this host element.
@@ -80,23 +54,57 @@ export const Shadowed: TOC<{
      */
     default: [];
   };
-}> = <template>
-  {{#let (Shadow) as |shadow|}}
-    {{! TODO: We need a way in ember to render in to a shadow dom without an effect }}
-    <div {{shadow.attach}} ...attributes></div>
+}> {
+  shadow: HTMLDivElement;
+  host: HTMLDivElement;
+  /**
+   * ember-source 5.6 broke the ability to in-element
+   * natively into a shadowroot.
+   *
+   * We have two or three more dives than we should have here.
+   *
+   *
+   * See these ember-source bugs:
+   * - https://github.com/emberjs/ember.js/issues/20643
+   * - https://github.com/emberjs/ember.js/issues/20642
+   * - https://github.com/emberjs/ember.js/issues/20641
+   *
+   * Ideally, shadowdom should be built in.
+   * Couple paths forward:
+   *  - (as the overall template tag)
+   *     <template shadowrootmode="open">
+   *     </template>
+   *
+   *  - Build a component into the framework that does the above ^
+   *  - add additional parsing in content-tag to allow
+   *    nested <template>
+   *
+   */
+  constructor(owner: Owner, args: { includeStyles?: boolean }) {
+    super(owner, args);
 
-    {{#if shadow.root}}
-      {{#in-element shadow.root}}
+    const element = document.createElement("div");
+    const shadowRoot = element.attachShadow({ mode: "open" });
+    const div = document.createElement("div");
 
-        {{#if @includeStyles}}
-          <Styles />
-        {{/if}}
+    shadowRoot.appendChild(div);
+    this.host = element;
+    this.shadow = div;
+  }
 
-        {{yield}}
+  <template>
+    <div ...attributes>{{this.host}}</div>
 
-      {{/in-element}}
-    {{/if}}
-  {{/let}}
-</template>;
+    {{#in-element this.shadow}}
+
+      {{#if @includeStyles}}
+        <Styles />
+      {{/if}}
+
+      {{yield}}
+
+    {{/in-element}}
+  </template>
+}
 
 export default Shadowed;

--- a/ember-primitives/src/test-support/dom.ts
+++ b/ember-primitives/src/test-support/dom.ts
@@ -1,0 +1,44 @@
+import { assert } from '@ember/debug';
+import { find } from '@ember/test-helpers';
+
+type Findable = Parameters<typeof find>[0] | Element;
+
+/**
+ * Find an element within a shadow-root.
+ */
+export function findInShadow(root: Findable, query: string) {
+  const rootElement = root instanceof Element ? root : find(root);
+
+  return rootElement?.shadowRoot?.querySelector(query);
+}
+
+/**
+ * Does the element have a shadow root?
+ */
+export function hasShadowRoot(el: Element) {
+  return Boolean(el.shadowRoot);
+}
+
+export function findShadow(root?: Findable) {
+  const rootElement = root
+    ? root instanceof Element
+      ? root
+      : find(root)
+    : document.getElementById('ember-testing');
+
+  if (!rootElement) return;
+
+  for (const element of rootElement.querySelectorAll('*')) {
+    if (element.shadowRoot) {
+      return element;
+    }
+  }
+}
+
+export function findInFirstShadow(query: string) {
+  const host = findShadow();
+
+  assert(`No element with a shadow root could be found`, host);
+
+  return findInShadow(host, query);
+}

--- a/ember-primitives/src/test-support/index.ts
+++ b/ember-primitives/src/test-support/index.ts
@@ -1,4 +1,5 @@
 export { setupTabster } from './a11y.ts';
+export { findInFirstShadow, findInShadow, findShadow, hasShadowRoot } from './dom.ts';
 export { fillOTP } from './otp.ts';
 export { rating } from './rating.ts';
 export { getRouter, setupRouting } from './routing.ts';

--- a/test-app/tests/shadowed/rendering-test.gts
+++ b/test-app/tests/shadowed/rendering-test.gts
@@ -4,6 +4,8 @@ import { setupRenderingTest } from 'ember-qunit';
 
 import { Shadowed } from 'ember-primitives';
 
+import { findInFirstShadow } from 'ember-primitives/test-support';
+
 module('Rendering | <Shadowed>', function (hooks) {
   setupRenderingTest(hooks);
 
@@ -22,6 +24,6 @@ module('Rendering | <Shadowed>', function (hooks) {
     assert.dom().doesNotContainText('in shadow');
     // assort.dom forgot that ShadowDom is a thing
     // assert.dom(find('[data-shadow]')?.shadowRoot).hasText('in shadow');
-    assert.ok(find('[data-shadow]')?.shadowRoot?.textContent?.includes('in shadow'));
+    assert.dom(findInFirstShadow('*')).containsText('in shadow');
   });
 });


### PR DESCRIPTION
Extracted from 
- #564

Downside is that this adds yet another div, to maintain the public API of allowing `...attributes`.

However, the fewer render cycles we can be "settled" in, the better (shorten time-to-interactive).
This should also mean better SSR support as well for `<Shadowed>`

