### PR TITLE
Bundle per-component entrypoints / hides the little helper files that some of the more complex components have 

### DIFF
--- a/ember-primitives/rollup.config.mjs
+++ b/ember-primitives/rollup.config.mjs
@@ -13,7 +13,21 @@ const extensions = [".js", ".ts", ".gts", ".gjs", ".hbs", ".json"];
 export default {
   output: addon.output(),
   plugins: [
-    addon.publicEntrypoints(["**/*.js"], { exclude: ["*/**/index.*"] }),
+    addon.publicEntrypoints(["**/*.js"], {
+      exclude: [
+        "*/**/index.*",
+        /**
+         * These globs are because we have better entrypoints
+         */
+        "test-support/*",
+        "floating-ui/*",
+        "components/-private/*",
+        "components/accordion/*",
+        "components/rating/*",
+        "components/zoetrope/*",
+        "components/one-time-password/*",
+      ],
+    }),
     // Services are the only thing we can't rely on auto-import
     // handling for us.
     addon.appReexports(["services/**/*.js"]),


### PR DESCRIPTION
These files are for source-organization, and less so about public API.

These changes make only what is importable align with what is public API