### PR TITLE
Update link helper to use `event.currentTarget`

### DIFF
--- a/ember-primitives/src/helpers/link.ts
+++ b/ember-primitives/src/helpers/link.ts
@@ -35,9 +35,9 @@ export default class Link extends Helper<Signature> {
 
     const router = this.router;
     const handleClick = (event: MouseEvent) => {
-      assert('[BUG]', event.target instanceof HTMLAnchorElement);
+      assert('[BUG]', event.currentTarget instanceof HTMLAnchorElement);
 
-      handle(router, event.target, [], event);
+      handle(router, event.currentTarget, [], event);
     };
 
     return {


### PR DESCRIPTION
If you were using the `Link` component with a nested `span` element

```handlebars
<Link @href="/">
  <span>This is a link</span>
</Link>
```

 and you used your mouse to click on the link, you would get an assertion error:

<img width="606" height="63" alt="Screenshot 2025-12-10 at 2 01 20 PM" src="https://github.com/user-attachments/assets/f319bb21-f297-49e6-a652-5bb06999f57e" />

It's because the link helper under the hood was using `event.target`, which happens to be a `span` in this case. The helper expects it to be an anchor tag. Changing it to `event.currentTarget` fixes this issue.

I'm not really sure how to add a test for this because the `click` test helper will always click the anchor tag.