### PR TITLE
Move menu toggle to the items

### DIFF
--- a/test-app/tests/menu/menu-rendering-test.gts
+++ b/test-app/tests/menu/menu-rendering-test.gts
@@ -149,6 +149,66 @@ module('Rendering | menu', function (hooks) {
     assert.dom('.trigger').isFocused();
   });
 
+  test('can be closed by clicking a menu item', async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+
+        <Menu as |m|>
+          <m.Trigger class="trigger">
+            Trigger
+          </m.Trigger>
+
+          <m.Content class="content" as |c|>
+            <c.Item>Item 1</c.Item>
+          </m.Content>
+        </Menu>
+      </template>
+    );
+
+    assert.dom('.content').doesNotExist();
+
+    await click('.trigger');
+
+    assert.dom('.content').exists({ count: 1 });
+    assert.dom('.trigger').hasAttribute('aria-expanded', 'true');
+
+    await click('[role="menuitem"]');
+
+    assert.dom('.trigger').hasAttribute('aria-expanded', 'false');
+    assert.dom('.content').doesNotExist();
+  });
+
+  test('can be closed by clicking a menu link item', async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+
+        <Menu as |m|>
+          <m.Trigger class="trigger">
+            Trigger
+          </m.Trigger>
+
+          <m.Content class="content" as |c|>
+            <c.LinkItem @href="/">Item 1</c.LinkItem>
+          </m.Content>
+        </Menu>
+      </template>
+    );
+
+    assert.dom('.content').doesNotExist();
+
+    await click('.trigger');
+
+    assert.dom('.content').exists({ count: 1 });
+    assert.dom('.trigger').hasAttribute('aria-expanded', 'true');
+
+    await click('[role="menuitem"]');
+
+    assert.dom('.trigger').hasAttribute('aria-expanded', 'false');
+    assert.dom('.content').doesNotExist();
+  });
+
   test('keyboard navigation works', async function (assert) {
     await render(
       <template>


### PR DESCRIPTION
If you have a `Menu` thats fixed in your app and then you click a `LinkItem` to navigate to another route in your app, the menu content will still be displaying. This is because it seems that the click event on the link isn't bubbling up to the `Content` component's click handler.

This moves the `toggle` click handler to the `Item` and `LinkItem` components of a `Menu` rather than on the `Content` component. This way, clicking on a `LinkItem` will always fire the toggle of the menu.

This fixes #591 