### PR TITLE
Simplify event handling in proper-links.ts

### DIFF
--- a/ember-primitives/src/proper-links.ts
+++ b/ember-primitives/src/proper-links.ts
@@ -123,8 +123,6 @@ export function handle(
 
     if (routeInfo) {
       event.preventDefault();
-      event.stopImmediatePropagation();
-      event.stopPropagation();
 
       router.transitionTo(withoutRootURL);
 


### PR DESCRIPTION
Stopping all propagation will swallow other events.

For example when using [ember-click-outside](https://github.com/zeppelin/ember-click-outside) if you click on a link the event for click outside will not fire.

The only thing we want to stop is the browsers default link handling.