### PR TITLE
Fix deploy preview checkout for fork PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -68,6 +68,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
           ref: ${{ github.event.workflow_run.head_branch }}
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v3


### PR DESCRIPTION
## Summary

The Deploy Preview workflow fails for fork PRs because `actions/checkout` tries to fetch the PR's head branch from the upstream repo, where it doesn't exist.

The checkout step uses `ref: ${{ github.event.workflow_run.head_branch }}` but doesn't specify a `repository`, so it defaults to `github.repository` (the upstream). For fork PRs the branch only exists on the fork, causing:

```
git fetch origin +refs/heads/<branch>*:refs/remotes/origin/<branch>*
The process '/usr/bin/git' failed with exit code 1
```

### Fix

Add `repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}` to the checkout step. This fetches from the fork repo for `workflow_run` events, and falls back to the current repo for `workflow_dispatch` (where `workflow_run` context doesn't exist).

## Test plan

- [ ] Trigger a deploy preview from a fork PR — should successfully check out and build
- [ ] `workflow_dispatch` still works (falls back to `github.repository`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)