### PR TITLE
Fix injected deps sync when turbo replays cached builds

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -24,7 +24,7 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
+    "sync": "pnpm install --frozen-lockfile",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
+    "sync": "pnpm install --frozen-lockfile",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Deploy Preview (and potentially other CI jobs) fail with:

```
Rollup failed to resolve import "ember-primitives/on-resize" from
".../ember-mobile-menu/dist/components/mobile-menu-wrapper.js"
```

### Root cause

`ember-mobile-menu` has `ember-primitives` as a direct dependency. With `inject-workspace-packages=true` and `dedupe-injected-deps=true`, pnpm deduplicates it to the workspace copy in the pnpm store (`ember-primitives@file+ember-primitives`).

The sync scripts in docs-app and test-app were no-op echo stubs:
```json
"sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'"
```

These relied on pnpm's `sync-injected-deps-after-scripts[]=build` hook to re-copy `dist/` into the injected store entry after building. But when **turbo replays a cached build**, pnpm doesn't run the build script — turbo restores the outputs directly to `ember-primitives/dist/`. The pnpm hook never fires, so the injected copy in the store stays empty (no `dist/`). Then `ember-mobile-menu` resolves `ember-primitives/on-resize` through the store copy and fails.

### Fix

Change the `sync` scripts to run `pnpm install --frozen-lockfile`, which re-syncs injected deps from the workspace source (now including `dist/`) without modifying the lockfile.

The turbo task `_syncPnpm` already has `"cache": false` and `"dependsOn": ["^build"]`, so this sync always runs after upstream builds complete — whether from cache or fresh.

## Test plan

- [ ] `pnpm turbo build:dev` succeeds locally
- [ ] Deploy Preview CI passes
- [ ] Default Tests still pass (test-app sync also updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)