### PR TITLE
Fix injected deps sync when turbo replays cached builds

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -24,7 +24,7 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
+    "sync": "pnpm install --frozen-lockfile",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -22,7 +22,7 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
+    "sync": "pnpm install --frozen-lockfile",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -79,7 +79,7 @@
       "outputs": ["dist/**", "dist-types/**", "declarations/**", "docs.json"],
       "dependsOn": ["_syncPnpm", "//#sync"]
     },
-    "//#sync": {},
+    "//#sync": { "cache": false },
     "_syncPnpm": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
## Summary

Deploy Preview fails on `main` with:

```
Rollup failed to resolve import "ember-primitives/on-resize" from
".../ember-mobile-menu/dist/components/mobile-menu-wrapper.js"
```

### Root cause

`ember-mobile-menu` resolves `ember-primitives` through the pnpm store's injected workspace copy. When turbo replays `ember-primitives:build` from cache, the `dist/` files are restored to `ember-primitives/dist/` but the injected copy in the pnpm store is never updated — two things prevent it:

1. **`//#sync` is cached by turbo** — the root sync task has no `"cache": false`, so turbo replays cached logs instead of re-executing
2. **Sync scripts are no-op stubs** — they echo a message, relying on pnpm's `sync-injected-deps-after-scripts[]=build` hook. But that hook only fires when pnpm runs the build script — not when turbo restores outputs from cache

### Fix

- Add `"cache": false` to `//#sync` in turbo.json
- Change sync scripts to `pnpm install --frozen-lockfile` which re-syncs injected deps

## Test plan

Once merged, `workflow_dispatch` the Deploy Preview targeting PR #699 to verify docs-app builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)