### PR TITLE
Move injected deps sync to _syncPnpm (runs after builds)

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -24,7 +24,8 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "pnpm install --frozen-lockfile",
+    "_syncPnpm": "pnpm install --frozen-lockfile",
+    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -22,7 +22,8 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "sync": "pnpm install --frozen-lockfile",
+    "_syncPnpm": "pnpm install --frozen-lockfile",
+    "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },
   "dependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -79,7 +79,7 @@
       "outputs": ["dist/**", "dist-types/**", "declarations/**", "docs.json"],
       "dependsOn": ["_syncPnpm", "//#sync"]
     },
-    "//#sync": { "cache": false },
+    "//#sync": {},
     "_syncPnpm": {
       "dependsOn": ["^build"],
       "cache": false


### PR DESCRIPTION
## Summary

Follow-up to #703. The sync scripts in `//#sync` run **before** `ember-primitives:build` (no `dependsOn`), so injected deps were synced before `dist/` existed — same failure.

### Fix

Add `_syncPnpm` scripts (`pnpm install --frozen-lockfile`) to docs-app and test-app. The `_syncPnpm` turbo task has `dependsOn: ["^build"]` and `cache: false`, so it runs **after** upstream builds and **before** downstream consumers.

Execution order:
1. `//#sync` — runs echo stubs (harmless, before builds)
2. `ember-primitives:build` — produces `dist/`
3. `docs-app#_syncPnpm` → `pnpm install --frozen-lockfile` — re-syncs injected deps (now includes `dist/`)
4. `docs-app:build:dev` — vite build succeeds

Also reverts `//#sync` back to cacheable since it only runs echo stubs.

## Test plan

Once merged, workflow_dispatch Deploy Preview targeting PR #699.

🤖 Generated with [Claude Code](https://claude.com/claude-code)