### PR TITLE
Fix deploy preview workflow_dispatch by resolving PR info upfront

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -60,6 +60,41 @@ env:
 
 
 jobs:
+  # debug:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - run: echo "${{ toJson(github.event) }}"
+  #     - run: echo "${{ toJson(github.event.workflow_run) }}"
+
+  determinePR:
+    # this job gates the others -- if the workflow_run request did not come from a PR,
+    # exit as early as possible
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' || github.event.inputs.prNum
+    outputs:
+      number: ${{ steps.pr-info.outputs.number }}
+      branch: ${{ steps.pr-info.outputs.branch }}
+      repo: ${{ steps.pr-info.outputs.repo }}
+    steps:
+      - id: pr-info
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -n "${{ github.event.inputs.prNum }}" ]; then
+            PR_NUM="${{ github.event.inputs.prNum }}"
+            PR_JSON=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefName,headRepository)
+            BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
+            REPO=$(echo "$PR_JSON" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
+          else
+            PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
+            BRANCH="${{ github.event.workflow_run.head_branch }}"
+            REPO="${{ github.event.workflow_run.head_repository.full_name }}"
+          fi
+
+          echo "number=$PR_NUM" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "repo=${REPO:-${{ github.repository }}}" >> "$GITHUB_OUTPUT"
+
   # This is the only job that needs access to the source code
   Build:
     runs-on: ubuntu-latest
@@ -68,8 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
-          ref: ${{ github.event.workflow_run.head_branch }}
+          repository: ${{ needs.determinePR.outputs.repo }}
+          ref: ${{ needs.determinePR.outputs.branch }}
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v3
         with:
@@ -90,28 +125,11 @@ jobs:
 # Does not checkout code, has access to secrets
 #################################################################
 
-  # debug:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - run: echo "${{ toJson(github.event) }}"
-  #     - run: echo "${{ toJson(github.event.workflow_run) }}"
-
-  determinePR:
-    # this job gates the others -- if the workflow_run request did not come from a PR,
-    # exit as early as possible
-    runs-on: ubuntu-latest
-    if: github.event.workflow_run.event == 'pull_request' || github.event.inputs.prNum
-    outputs:
-      number: ${{ steps.number.outputs.pr-number }}
-    steps:
-      - run: echo "${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.prNum }}"
-        id: number
-
   DeployPreview_Docs:
     name: "Deploy: Preview"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [Build]
+    needs: [Build, determinePR]
     permissions:
       contents: read
       deployments: write
@@ -123,7 +141,7 @@ jobs:
       - id: deploy
         uses: cloudflare/pages-action@v1.5.0
         with:
-          branch: ${{ github.event.workflow_run.head_branch }}
+          branch: ${{ needs.determinePR.outputs.branch }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           projectName: ember-primitives
@@ -133,14 +151,14 @@ jobs:
   PostComment:
     name: Post Preview URL as comment to PR
     runs-on: ubuntu-latest
-    needs: [DeployPreview_Docs]
+    needs: [DeployPreview_Docs, determinePR]
     permissions:
       pull-requests: write
     steps:
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: preview-urls
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ needs.determinePR.outputs.number }}
           message: |+
             | Project   | Preview URL |
             | -------   | ----------- |


### PR DESCRIPTION
## Summary

The deploy preview workflow uses `github.event.workflow_run` context for branch name, repo, and PR number — but these are all empty for `workflow_dispatch` triggers, causing:

- Empty `ref` on checkout → builds `main` instead of the PR branch
- Empty `--branch` on Cloudflare deploy → wrangler crashes
- Missing PR number on sticky comment

### Fix

Centralize PR info resolution in `determinePR`. For `workflow_dispatch`, use `gh pr view` to look up the branch and repo from the PR number input. Pass `branch`, `repo`, and `number` as job outputs consumed by Build, Deploy, and PostComment.

## Test plan

- [ ] `workflow_dispatch` with PR number → checks out correct branch, deploys, posts comment
- [ ] `workflow_run` from CI → same behavior as before (uses workflow_run context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)