### PR TITLE
Fix headRepository owner lookup in deploy preview

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -82,9 +82,9 @@ jobs:
         run: |
           if [ -n "${{ github.event.inputs.prNum }}" ]; then
             PR_NUM="${{ github.event.inputs.prNum }}"
-            PR_JSON=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefName,headRepository)
+            PR_JSON=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefName,headRepository,headRepositoryOwner)
             BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
-            REPO=$(echo "$PR_JSON" | jq -r '.headRepository.owner.login + "/" + .headRepository.name')
+            REPO=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
           else
             PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
             BRANCH="${{ github.event.workflow_run.head_branch }}"


### PR DESCRIPTION
## Summary

Follow-up to #705. `gh pr view --json headRepository` returns the owner as a separate `headRepositoryOwner` top-level field, not nested inside `headRepository`. The jq expression was using `.headRepository.owner.login` which doesn't exist, producing `/ember-primitives` instead of `NullVoxPopuli-ai-agent/ember-primitives`.

One-line fix: `headRepositoryOwner.login` instead of `headRepository.owner.login`.

## Test plan

- [ ] `workflow_dispatch` Deploy Preview with PR #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)