### PR TITLE
Hoist ember-primitives to fix transitive dep resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -15,6 +15,7 @@ peers-suffix-max-length=40
 dedupe-injected-deps=true
 dedupe-peer-dependents=true
 public-hoist-pattern[]=ember-source
+public-hoist-pattern[]=ember-primitives
 sync-injected-deps-after-scripts[]=build
 sync-injected-deps-after-scripts[]=sync
 inject-workspace-packages=true


### PR DESCRIPTION
## Summary

`ember-mobile-menu` depends on `ember-primitives` directly. Despite the `workspace:^` override, pnpm's strict isolation resolves it through the store's injected copy. When turbo replays cached builds, there's a race condition where the injected copy may not have `dist/` synced yet, causing:

```
Rollup failed to resolve import "ember-primitives/on-resize"
```

Adding `public-hoist-pattern[]=ember-primitives` to `.npmrc` ensures all packages resolve to the same hoisted copy in root `node_modules`, which is always current after builds. This is safe because the `workspace:^` override already forces all consumers to use the workspace version.

## Test plan

- [ ] `workflow_dispatch` Deploy Preview targeting PR #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)