### PR TITLE
Fix deploy-preview concurrency group to be per-PR

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,7 +50,7 @@ on:
       - requested
 
 concurrency:
-  group: deploy-preview-${{ github.ref }}
+  group: deploy-preview-${{ github.event.workflow_run.pull_requests[0].number || github.event.inputs.prNum || github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary
- The deploy-preview workflow's concurrency group used `github.ref`, which for `workflow_run` events is always the default branch (`main`)
- This caused every deploy-preview run to share the same concurrency group, so runs for different PRs (and `workflow_dispatch` triggers) would cancel each other
- Now uses the PR number for the concurrency group, falling back to `github.ref` for non-PR contexts

## Test plan
- [ ] Trigger deploy previews for two different PRs concurrently and verify they don't cancel each other
- [ ] Trigger `workflow_dispatch` and verify it doesn't cancel unrelated deploy-preview runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)