### PR TITLE
Fix deploy preview comments on fork PRs

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -86,7 +86,13 @@ jobs:
             BRANCH=$(echo "$PR_JSON" | jq -r '.headRefName')
             REPO=$(echo "$PR_JSON" | jq -r '.headRepositoryOwner.login + "/" + .headRepository.name')
           else
+            # For fork PRs, pull_requests[] is empty, so look up by SHA
             PR_NUM="${{ github.event.workflow_run.pull_requests[0].number }}"
+            if [ -z "$PR_NUM" ]; then
+              HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+              PR_NUM=$(gh pr list --repo "${{ github.repository }}" --json number,headRefOid \
+                --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | .number")
+            fi
             BRANCH="${{ github.event.workflow_run.head_branch }}"
             REPO="${{ github.event.workflow_run.head_repository.full_name }}"
           fi


### PR DESCRIPTION
## Summary

- GitHub omits `workflow_run.pull_requests[]` for workflows triggered by fork PRs (security measure to protect private repos)
- This caused the deploy preview workflow to skip or fail silently on fork PRs since the PR number couldn't be determined
- Added a fallback that looks up the PR number via `gh pr list` using the head SHA when the array is empty

## Test plan

- [ ] Open a PR from a fork and verify the deploy preview comment appears
- [ ] Verify same-repo PRs still get deploy preview comments as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)