### PR TITLE
Fix Deploy: Production wrangler install failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,25 +159,12 @@ jobs:
       - run: pnpm test:ember
         working-directory: docs-app
 
-  DeployProduction:
-    name: "Deploy: Production"
+  BuildProduction:
+    name: "Build: Production"
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [setup]
-    strategy:
-      matrix:
-        app:
-          - {
-              path: "./docs-app/dist",
-              cloudflareName: "ember-primitives",
-              name: "docs",
-            }
-
-    permissions:
-      contents: read
-      deployments: write
-
     steps:
       - uses: wyvox/action@v2
         with:
@@ -186,9 +173,33 @@ jobs:
       - run: pnpm i -f # sync for some reason isn't running before lint
       - run: pnpm build:dev # should be prod. it is prod. but the script is named wrong
         working-directory: docs-app
-      - name: Publish ${{ matrix.app.id }}
+      - uses: actions/upload-artifact@v7
+        with:
+          name: docs-app-dist
+          if-no-files-found: error
+          path: |
+            ./docs-app/dist/**/*
+            !node_modules/
+            !./**/node_modules/
+
+  DeployProduction:
+    name: "Deploy: Production"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [BuildProduction]
+
+    permissions:
+      contents: read
+      deployments: write
+
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs-app-dist
+          path: docs-app-dist
+      - name: Publish
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy ${{ matrix.app.path }} --project-name=${{ matrix.app.cloudflareName }}
+          command: pages deploy ./docs-app-dist/ --project-name=ember-primitives


### PR DESCRIPTION
## Summary
- Split `DeployProduction` into separate `BuildProduction` and `DeployProduction` jobs
- Build job checks out code, builds docs-app, and uploads the dist as an artifact
- Deploy job only downloads the artifact and runs wrangler — no repo checkout means no `pnpm-lock.yaml`, so wrangler-action falls back to `npm` (matching the existing deploy-preview pattern)

## Problem
`cloudflare/wrangler-action@v3` detects pnpm from the lockfile and runs `pnpm add wrangler`, which fails in a workspace with `ERR_PNPM_ADDING_TO_ROOT` (requires `-w` flag the action doesn't pass).

## Test plan
- [ ] CI passes on this PR
- [ ] Merge to main triggers a successful production deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)