### PR TITLE
Prevent color scheme update if local preference is set

### DIFF
--- a/ember-primitives/src/color-scheme.ts
+++ b/ember-primitives/src/color-scheme.ts
@@ -110,6 +110,7 @@ const queries = {
 };
 
 queries.dark.addEventListener('change', (e) => {
+  if (localPreference.isSet()) return;
   const mode = e.matches ? 'dark' : 'light';
 
   colorScheme.update(mode);

--- a/ember-primitives/src/color-scheme.ts
+++ b/ember-primitives/src/color-scheme.ts
@@ -111,6 +111,7 @@ const queries = {
 
 queries.dark.addEventListener('change', (e) => {
   if (localPreference.isSet()) return;
+
   const mode = e.matches ? 'dark' : 'light';
 
   colorScheme.update(mode);


### PR DESCRIPTION
Discovered this because when your bring up the print dialoge on a page that has it's local preference set to opposite the current system theme the media queries run again and you theme gets set to the system theme.