### PR TITLE
Replace portals with Popover API for layering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm i -f # ensure all bin symlinks are created
+      - run: ls packages/docs-support/node_modules/.bin/ember-tsc || pnpm --filter @universal-ember/docs-support install
       - run: pnpm build
       - id: set-pending
         run: echo "pending=$(./cache-status.sh)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
       - uses: wyvox/action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: pnpm i -f # ensure all bin symlinks are created
       - run: pnpm build
       - id: set-pending
         run: echo "pending=$(./cache-status.sh)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - run: pnpm i -f # ensure all bin symlinks are created
-      - run: ls packages/docs-support/node_modules/.bin/ember-tsc || pnpm --filter @universal-ember/docs-support install
       - run: pnpm build
       - id: set-pending
         run: echo "pending=$(./cache-status.sh)" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - uses: wyvox/action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - run: pnpm i -f # ensure all bin symlinks are created
       - run: pnpm build
       - run: pnpm i -f # sync for some reason isn't running before lint
       - run: ls -la ember-primitives/

--- a/docs-app/app/templates/5-floaty-bits/menu.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/menu.gjs.md
@@ -170,4 +170,4 @@ The `@inline` argument has been removed. Menu content now renders inline in the 
 
 ### CSS considerations
 
-The browser's `[popover]` UA stylesheet adds default `border` and `overflow` styles. You may need to set `border: none` on your menu content if you don't want the browser's default border. The component resets `overflow: visible` automatically.
+The `popover` HTML attribute has a browser UA stylesheet that adds default `border` and `overflow` styles to elements with `[popover]`. You may need to set `border: none` on your menu content if you don't want the browser's default `[popover]` border. The component resets `overflow: visible` automatically.

--- a/docs-app/app/templates/5-floaty-bits/menu.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/menu.gjs.md
@@ -1,19 +1,17 @@
 # Menu
 
-Menus are built with Popovers, with added features for keyboard navigation and accessibility. 
+Menus are built with Popovers, with added features for keyboard navigation and accessibility.
 
 The placement of the menu content is handled by `<Popover>`, so `<Menu>` accepts the same arguments for positioning the dropdown.
 
-Like `<Popover>`, the `<Menu>` component uses portals in a way that totally solves layering issues. No more worrying about tooltips on varying layers of your UI sometimes appearing behind other floaty bits. See the `<Portal>` and `<PortalTargets>` pages for more information.
+Like `<Popover>`, the `<Menu>` component uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for layering, which totally solves z-index and overflow clipping issues, no portals needed.
 
 <div class="featured-demo">
 
 ```gjs live preview no-shadow
-import { PortalTargets, Menu } from 'ember-primitives';
+import { Menu } from "ember-primitives";
 
 <template>
-  <PortalTargets />
-
   <Menu @offsetOptions={{8}} as |m|>
     <m.Trigger class="trigger" aria-label="Options">
       <EllipsisVertical />
@@ -38,7 +36,11 @@ import { PortalTargets, Menu } from 'ember-primitives';
       border: none;
       font-size: 14px;
       z-index: 10;
-      box-shadow: 0 0 #0000, 0 0 #0000, 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+      box-shadow:
+        0 0 #0000,
+        0 0 #0000,
+        0 10px 15px -3px rgb(0 0 0 / 0.1),
+        0 4px 6px -4px rgb(0 0 0 / 0.1);
       display: flex;
       flex-direction: column;
     }
@@ -50,7 +52,8 @@ import { PortalTargets, Menu } from 'ember-primitives';
       cursor: pointer;
     }
 
-    .content [role="menuitem"]:focus, .trigger:hover {
+    .content [role="menuitem"]:focus,
+    .trigger:hover {
       background-color: #f9fafb;
     }
 
@@ -79,15 +82,19 @@ import { PortalTargets, Menu } from 'ember-primitives';
 </template>
 
 const EllipsisVertical = <template>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 512" fill="currentColor"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M64 360a56 56 0 1 0 0 112 56 56 0 1 0 0-112zm0-160a56 56 0 1 0 0 112 56 56 0 1 0 0-112zM120 96A56 56 0 1 0 8 96a56 56 0 1 0 112 0z"/></svg>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 128 512"
+    fill="currentColor"
+  ><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path
+      d="M64 360a56 56 0 1 0 0 112 56 56 0 1 0 0-112zm0-160a56 56 0 1 0 0 112 56 56 0 1 0 0-112zM120 96A56 56 0 1 0 8 96a56 56 0 1 0 112 0z"
+    /></svg>
 </template>;
 ```
 
 </div>
 
-
 Sometimes, you need to use an existing component as the trigger. `<Menu>` also yields a `trigger` modifier that you can use anywhere, even on your own components (e.g a custom button):
-
 
 ```hbs
 <Menu as |m|>
@@ -106,25 +113,23 @@ Sometimes, you need to use an existing component as the trigger. `<Menu>` also y
 
 Keep in mind that for the modifier to do its work, your custom component must use [`...attributes`](https://guides.emberjs.com/v5.7.0/components/component-arguments-and-html-attributes/#toc_html-attributes) in some HTML element.
 
-
 ## Install
-
 
 ```hbs live
 <SetupInstructions @src="components/menu.gts" />
 ```
 
-
 ## API Reference
 
 ```gjs live no-shadow
-import { ComponentSignature } from 'kolay';
+import { ComponentSignature } from "kolay";
 
 <template>
-  <ComponentSignature 
-    @package="ember-primitives" 
-    @module="declarations/components/menu" 
-    @name="Signature" />
+  <ComponentSignature
+    @package="ember-primitives"
+    @module="declarations/components/menu"
+    @name="Signature"
+  />
 </template>
 ```
 
@@ -134,9 +139,35 @@ Adheres to the [Menu Button WAI-ARIA design pattern](https://www.w3.org/WAI/ARIA
 
 ### Keyboard Interactions
 
-| key | description |
-| :---: | :----------- |
-| <kbd>Space</kbd> <kbd>Enter</kbd>  | When focus is on `Trigger`, opens the menu and focuses the first item. When focus is on an `Item`, activates the focused item. |
-| <kbd>ArrowDown</kbd> <kbd>ArrowRight</kbd> | When `Content` is open, moves to the next item.  |
-| <kbd>ArrowUp</kbd> <kbd>ArrowLeft</kbd> | When `Content` is open, moves to the previous item.  |
-| <kbd>Esc</kbd> | Closes the menu and moves focus to `Trigger`. |
+|                    key                     | description                                                                                                                    |
+| :----------------------------------------: | :----------------------------------------------------------------------------------------------------------------------------- |
+|     <kbd>Space</kbd> <kbd>Enter</kbd>      | When focus is on `Trigger`, opens the menu and focuses the first item. When focus is on an `Item`, activates the focused item. |
+| <kbd>ArrowDown</kbd> <kbd>ArrowRight</kbd> | When `Content` is open, moves to the next item.                                                                                |
+|  <kbd>ArrowUp</kbd> <kbd>ArrowLeft</kbd>   | When `Content` is open, moves to the previous item.                                                                            |
+|               <kbd>Esc</kbd>               | Closes the menu and moves focus to `Trigger`.                                                                                  |
+
+## Migrating from <= v0.55
+
+### Remove `<PortalTargets />`
+
+`<Menu>` now uses the browser's Popover API for layering. You no longer need `<PortalTargets />` in your templates.
+
+```diff
+- import { PortalTargets, Menu } from 'ember-primitives';
++ import { Menu } from 'ember-primitives/components/menu';
+
+  <template>
+-   <PortalTargets />
+    <Menu as |m|>
+      ...
+    </Menu>
+  </template>
+```
+
+### Remove `@inline`
+
+The `@inline` argument has been removed. Menu content now renders inline in the DOM and uses the Popover API for layering.
+
+### CSS considerations
+
+The browser's `[popover]` UA stylesheet adds default `border` and `overflow` styles. You may need to set `border: none` on your menu content if you don't want the browser's default border. The component resets `overflow: visible` automatically.

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -1,9 +1,6 @@
 # Popover
 
-Popovers are built with [Floating UI][docs-floating-ui], a set of utilities for making floating elements relate to each other with minimal configuration. 
-
-
-The `<Popover>` component uses portals in a way that totally solves layering issues. No more worrying about tooltips on varying layers of your UI sometimes appearing behind other floaty bits. See the `<Portal>` and `<PortalTargets>` pages for more information.
+Popovers are built with [Floating UI][docs-floating-ui], a set of utilities for making floating elements relate to each other with minimal configuration. The `<Popover>` component uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for layering, which totally solves z-index and overflow clipping issues — no portals needed.
 
 One thing to note is that the position of the popover can _escape_ the boundary of a [ShadowDom][docs-shadow-dom] -- all demos on this docs site for `ember-primitives` use a `ShadowDom` to allow for isolated CSS usage within the demos.
 
@@ -15,20 +12,19 @@ One thing to note is that the position of the popover can _escape_ the boundary 
 <div class="featured-demo">
 
 ```gjs live preview
-import { PortalTargets, Popover } from 'ember-primitives';
-import { array, hash } from '@ember/helper';
-import { loremIpsum } from 'lorem-ipsum';
+import { Popover } from "ember-primitives";
+import { array, hash } from "@ember/helper";
+import { loremIpsum } from "lorem-ipsum";
 
 <template>
-  <PortalTargets />
-
   <div class="scroll-content" tabindex="0">
     {{loremIpsum (hash count=1 units="sentence")}}
 
     <Popover @placement="top" @offsetOptions={{8}} as |p|>
       <div class="hook" {{p.reference}}>
         the hook / anchor of the popover.
-        <br> it sticks the boundary of this element.
+        <br />
+        it sticks the boundary of this element.
       </div>
       <p.Content class="floatybit">
         The floaty bit here
@@ -50,7 +46,7 @@ import { loremIpsum } from 'lorem-ipsum';
         padding: 5px;
         border-radius: 4px;
         font-size: 90%;
-        filter: drop-shadow(0 0 0.75rem rgba(0,0,0,0.4));
+        filter: drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.4));
         z-index: 10;
       }
       .arrow {
@@ -83,62 +79,60 @@ import { loremIpsum } from 'lorem-ipsum';
 
 It's often common to provide popover-using UIs in site headers, such as a settings menu, or navigation.
 
-
 <div class="featured-demo">
 
 ```gjs live preview
-import { PortalTargets, Popover } from 'ember-primitives';
-import { hash } from '@ember/helper';
-import { loremIpsum } from 'lorem-ipsum';
-import { cell } from 'ember-resources';
-import { on } from '@ember/modifier';
-import { focusTrap } from 'ember-focus-trap';
+import { Popover } from "ember-primitives";
+import { hash } from "@ember/helper";
+import { loremIpsum } from "lorem-ipsum";
+import { cell } from "ember-resources";
+import { on } from "@ember/modifier";
+import { focusTrap } from "ember-focus-trap";
 
 const settings = cell(false);
 
 <template>
-    <div class="site not-prose">
-      <PortalTargets />
+  <div class="site not-prose">
 
-        <header>
-            <span style="color: black">My App: click settings -&gt;</span>
+    <header>
+      <span style="color: black">My App: click settings -&gt;</span>
 
-            <Popover @offsetOptions={{8}} as |p|>
-              <button class="hook" {{p.reference}} {{on 'click' settings.toggle}}>
-                Settings
-              </button>
+      <Popover @offsetOptions={{8}} as |p|>
+        <button class="hook" {{p.reference}} {{on "click" settings.toggle}}>
+          Settings
+        </button>
 
-              {{#if settings.current}}
-                <p.Content @as="dialog" open class="floatybit">
-                  <PortalTargets />
-                  <ul>
-                    <li>a</li>
-                    <li>not so big list</li>
-                    <li>of</li>
-                    <li>
-                      things<br>
+        {{#if settings.current}}
+          <p.Content @as="dialog" open class="floatybit">
 
-                      <Popover @placement="left" @offsetOptions={{16}} as |pp|>
-                        <button {{pp.reference}}>view profile</button>
+            <ul>
+              <li>a</li>
+              <li>not so big list</li>
+              <li>of</li>
+              <li>
+                things<br />
 
-                        <pp.Content class="floatybit">
-                          View or edit your profile settings
-                          <div class="arrow" {{pp.arrow}}></div>
-                        </pp.Content>
-                      </Popover>
-                    </li>
-                  </ul>
-                  <div class="arrow" {{p.arrow}}></div>
-                </p.Content>
-              {{/if}}
-            </Popover>
+                <Popover @placement="left" @offsetOptions={{16}} as |pp|>
+                  <button {{pp.reference}}>view profile</button>
 
-        </header>
+                  <pp.Content class="floatybit">
+                    View or edit your profile settings
+                    <div class="arrow" {{pp.arrow}}></div>
+                  </pp.Content>
+                </Popover>
+              </li>
+            </ul>
+            <div class="arrow" {{p.arrow}}></div>
+          </p.Content>
+        {{/if}}
+      </Popover>
 
-        <div class="main">
-          {{loremIpsum (hash count=2 units="paragraphs")}}
-        </div>
+    </header>
+
+    <div class="main">
+      {{loremIpsum (hash count=2 units="paragraphs")}}
     </div>
+  </div>
 
   <style>
     @scope {
@@ -151,7 +145,7 @@ const settings = cell(false);
         padding: 1rem;
         border-radius: 4px;
         font-size: 90%;
-        filter: drop-shadow(0 0 0.75rem rgba(0,0,0,0.4));
+        filter: drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.4));
         z-index: 10;
         border: 1px solid rgba(0, 255, 255, 0.6);
       }
@@ -183,7 +177,7 @@ const settings = cell(false);
         border: 1px solid rgba(0, 255, 255, 0.6);
 
         &::before {
-          content: '';
+          content: "";
           position: absolute;
           display: block;
           width: 1rem;
@@ -191,7 +185,6 @@ const settings = cell(false);
           background: #222;
           transform: rotate(45deg);
           border-left: 1px solid rgba(0, 255, 255, 0.6);
-
         }
       }
       .hook {
@@ -219,7 +212,9 @@ const settings = cell(false);
         overflow-y: auto;
         border: 1px solid;
       }
-      * { box-sizing: border-box; }
+      * {
+        box-sizing: border-box;
+      }
     }
   </style>
 </template>
@@ -233,17 +228,17 @@ const settings = cell(false);
 <SetupInstructions @src="components/popover.gts" />
 ```
 
-
 ## API Reference
 
 ```gjs live no-shadow
-import { ComponentSignature } from 'kolay';
+import { ComponentSignature } from "kolay";
 
 <template>
-  <ComponentSignature 
-    @package="ember-primitives" 
-    @module="declarations/components/popover" 
-    @name="Signature" />
+  <ComponentSignature
+    @package="ember-primitives"
+    @module="declarations/components/popover"
+    @name="Signature"
+  />
 </template>
 ```
 
@@ -252,6 +247,7 @@ import { ComponentSignature } from 'kolay';
 The `Content` of a popover is focusable, so that keyboard (and screenreader) users can interact with the Popover content. Generally this is great for modals, but also extends to things like tooltips, so that folks can copy the content out.
 
 Since a `Popover` isn't an explicit design pattern provided by W3, but instead, `Popover` is a low level primitive that could be used to build the W3 examples of
+
 - [Modal Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/)
 - [Date Picker Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/datepicker-dialog/)
 - [Date Picker Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-datepicker/)

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -45,6 +45,7 @@ import { loremIpsum } from "lorem-ipsum";
         font-weight: bold;
         padding: 5px;
         border-radius: 4px;
+        border: none;
         font-size: 90%;
         filter: drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.4));
         z-index: 10;

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -99,15 +99,20 @@ import { Popover } from "ember-primitives";
 
   <style>
     @scope {
+      :scope {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
       .fancy-btn {
         padding: 0.5rem 1.5rem;
-        border-radius: 6px;
-        border: 1px solid #666;
-        background: #e2e8f0;
-        color: #334155;
+        border-radius: 4px;
+        border: 1px solid;
+        display: inline-block;
+        color: black;
+        background: white;
         font-weight: 600;
         cursor: not-allowed;
-        position: relative;
 
         &:hover + .tooltip,
         &:focus-visible + .tooltip {
@@ -120,15 +125,16 @@ import { Popover } from "ember-primitives";
         opacity: 0;
         pointer-events: none;
         transition: opacity 0.15s;
-        padding: 0.5rem 0.75rem;
         width: max-content;
         max-width: 260px;
-        background: #1e293b;
-        color: #f8fafc;
+        background: #222;
+        color: white;
+        font-weight: bold;
+        padding: 5px;
+        border-radius: 4px;
         border: none;
-        border-radius: 6px;
-        font-size: 0.85rem;
-        filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.3));
+        font-size: 90%;
+        filter: drop-shadow(0 0 0.75rem rgba(0, 0, 0, 0.4));
         z-index: 10;
 
         &:hover,
@@ -140,7 +146,7 @@ import { Popover } from "ember-primitives";
       }
       .arrow {
         position: absolute;
-        background: #1e293b;
+        background: #222;
         width: 8px;
         height: 8px;
         transform: rotate(45deg);

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -235,15 +235,15 @@ const settings = cell(false);
         border: 1px solid rgba(0, 255, 255, 0.6);
       }
       .floatybit .floatybit {
-        background: light-dark(#eee, #334155);
-        color: light-dark(black, #f8fafc);
+        background: light-dark(#eee, #1e293b);
+        color: light-dark(black, #f1f5f9);
       }
       .floatybit .floatybit .arrow {
-        background: light-dark(#eee, #334155);
+        background: light-dark(#eee, #1e293b);
         transform: translateY(-1rem) rotate(45deg);
 
         &::before {
-          background: light-dark(#eee, #334155);
+          background: light-dark(#eee, #1e293b);
           border-top: 1px solid rgba(0, 255, 255, 0.6);
           transform: rotate(45deg) translateY(7px) translateX(-8px);
           border-left: none;
@@ -274,18 +274,18 @@ const settings = cell(false);
       }
       .hook {
         padding: 0.5rem;
-        border: 1px solid currentColor;
+        border: 1px solid light-dark(#000, #e2e8f0);
         display: inline-block;
-        color: inherit;
-        background: light-dark(white, #1e293b);
+        color: light-dark(black, #f1f5f9);
+        background: light-dark(white, #0f172a);
         border-radius: 4px;
       }
       header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        background: light-dark(white, #1e293b);
-        color: light-dark(black, #f8fafc);
+        background: light-dark(white, #0f172a);
+        color: light-dark(black, #f1f5f9);
         position: sticky;
         top: 0;
         width: 100%;
@@ -294,12 +294,12 @@ const settings = cell(false);
       }
       .main {
         padding: 0.5rem;
-        color: light-dark(black, #cbd5e1);
+        color: light-dark(black, #94a3b8);
       }
       .site {
         max-height: 200px;
         overflow-y: auto;
-        border: 1px solid light-dark(#ccc, #334155);
+        border: 1px solid light-dark(#e2e8f0, #1e293b);
         color-scheme: light dark;
       }
       * {

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -1,6 +1,6 @@
 # Popover
 
-Popovers are built with [Floating UI][docs-floating-ui], a set of utilities for making floating elements relate to each other with minimal configuration. The `<Popover>` component uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for layering, which totally solves z-index and overflow clipping issues — no portals needed.
+Popovers are built with [Floating UI][docs-floating-ui], a set of utilities for making floating elements relate to each other with minimal configuration. The `<Popover>` component uses the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for layering, which totally solves z-index and overflow clipping issues, no portals needed.
 
 One thing to note is that the position of the popover can _escape_ the boundary of a [ShadowDom][docs-shadow-dom] -- all demos on this docs site for `ember-primitives` use a `ShadowDom` to allow for isolated CSS usage within the demos.
 
@@ -344,3 +344,43 @@ Since a `Popover` isn't an explicit design pattern provided by W3, but instead, 
 - [Select-Only Combobox](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-select-only/)
 - [Menu Button](https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/)
 - and more
+
+## Migrating from <= v0.55
+
+The `<Popover>` component now uses the browser's [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) for layering instead of portals.
+
+### Remove `<PortalTargets />`
+
+You no longer need `<PortalTargets />` in your templates. The Popover API promotes floating content to the browser's top layer natively.
+
+```diff
+- import { PortalTargets, Popover } from 'ember-primitives';
++ import { Popover } from 'ember-primitives';
+
+  <template>
+-   <PortalTargets />
+    <Popover as |p|>
+      <button {{p.reference}}>Toggle</button>
+      <p.Content>Floating content</p.Content>
+    </Popover>
+  </template>
+```
+
+### Remove `@inline`
+
+The `@inline` argument has been removed. All popover content now renders inline in the DOM and uses the Popover API for layering. If you were using `@inline={{true}}`, simply remove it.
+
+```diff
+- <p.Content @inline={{true}}>
++ <p.Content>
+```
+
+### CSS considerations
+
+The Popover API adds some default styles to `[popover]` elements (`border`, `padding`, `overflow`). The component resets `overflow: visible` automatically so arrows aren't clipped, but you may need to set `border: none` on your floating content if you don't want the default border:
+
+```css
+.my-popover-content {
+  border: none;
+}
+```

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -180,7 +180,7 @@ const settings = cell(false);
   <div class="site not-prose">
 
     <header>
-      <span style="color: black">My App: click settings -&gt;</span>
+      <span>My App: click settings -&gt;</span>
 
       <Popover @offsetOptions={{8}} as |p|>
         <button class="hook" {{p.reference}} {{on "click" settings.toggle}}>
@@ -235,15 +235,15 @@ const settings = cell(false);
         border: 1px solid rgba(0, 255, 255, 0.6);
       }
       .floatybit .floatybit {
-        background: #eee;
-        color: black;
+        background: light-dark(#eee, #334155);
+        color: light-dark(black, #f8fafc);
       }
       .floatybit .floatybit .arrow {
-        background: #eee;
+        background: light-dark(#eee, #334155);
         transform: translateY(-1rem) rotate(45deg);
 
         &::before {
-          background: #eee;
+          background: light-dark(#eee, #334155);
           border-top: 1px solid rgba(0, 255, 255, 0.6);
           transform: rotate(45deg) translateY(7px) translateX(-8px);
           border-left: none;
@@ -274,28 +274,33 @@ const settings = cell(false);
       }
       .hook {
         padding: 0.5rem;
-        border: 1px solid;
+        border: 1px solid currentColor;
         display: inline-block;
-        color: black;
+        color: inherit;
+        background: light-dark(white, #1e293b);
+        border-radius: 4px;
       }
       header {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        background: white;
+        background: light-dark(white, #1e293b);
+        color: light-dark(black, #f8fafc);
         position: sticky;
         top: 0;
         width: 100%;
-        padding: 0.25rem;
-        filter: drop-shadow(0px 3px 6px #000000aa);
+        padding: 0.25rem 0.5rem;
+        box-shadow: 0px 3px 6px #000000aa;
       }
       .main {
         padding: 0.5rem;
+        color: light-dark(black, #cbd5e1);
       }
       .site {
         max-height: 200px;
         overflow-y: auto;
-        border: 1px solid;
+        border: 1px solid light-dark(#ccc, #334155);
+        color-scheme: light dark;
       }
       * {
         box-sizing: border-box;

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -152,7 +152,7 @@ import { Popover } from "ember-primitives";
 
 </div>
 
-The tooltip is always in the DOM (for screen readers) but visually hidden via `opacity: 0`. On hover or focus of the button, CSS transitions it to `opacity: 1`. The tooltip itself is also hoverable/focusable so users can interact with it.
+The tooltip is always in the DOM (for screen readers) but visually hidden via `opacity: 0`. On hover or focus of the button, CSS transitions it to `opacity: 1`. The tooltip itself is hoverable and focusable, so users can select and copy the text within it — unlike native `title` attributes which don't allow interaction.
 
 ## Usage within a header
 

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -76,6 +76,84 @@ import { loremIpsum } from "lorem-ipsum";
 
 </div>
 
+## Disabled button with tooltip
+
+A common pattern is a button that explains _why_ it's disabled. The tooltip appears on hover and focus, and is itself focusable so screen reader users can read the reason.
+
+<div class="featured-demo">
+
+```gjs live preview
+import { Popover } from "ember-primitives";
+
+<template>
+  <Popover @placement="top" @offsetOptions={{6}} as |p|>
+    <button class="fancy-btn" aria-disabled="true" {{p.reference}}>
+      Submit
+    </button>
+
+    <p.Content @as="dialog" class="tooltip">
+      You must fill out all required fields before submitting.
+      <div class="arrow" {{p.arrow}}></div>
+    </p.Content>
+  </Popover>
+
+  <style>
+    @scope {
+      .fancy-btn {
+        padding: 0.5rem 1.5rem;
+        border-radius: 6px;
+        border: 1px solid #666;
+        background: #e2e8f0;
+        color: #334155;
+        font-weight: 600;
+        cursor: not-allowed;
+        position: relative;
+
+        &:hover + .tooltip,
+        &:focus-visible + .tooltip {
+          opacity: 1;
+          pointer-events: all;
+        }
+      }
+      .tooltip {
+        display: block;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.15s;
+        padding: 0.5rem 0.75rem;
+        width: max-content;
+        max-width: 260px;
+        background: #1e293b;
+        color: #f8fafc;
+        border: none;
+        border-radius: 6px;
+        font-size: 0.85rem;
+        filter: drop-shadow(0 2px 8px rgba(0, 0, 0, 0.3));
+        z-index: 10;
+
+        &:hover,
+        &:focus,
+        &:focus-visible {
+          opacity: 1;
+          pointer-events: all;
+        }
+      }
+      .arrow {
+        position: absolute;
+        background: #1e293b;
+        width: 8px;
+        height: 8px;
+        transform: rotate(45deg);
+      }
+    }
+  </style>
+</template>
+```
+
+</div>
+
+The tooltip is always in the DOM (for screen readers) but visually hidden via `opacity: 0`. On hover or focus of the button, CSS transitions it to `opacity: 1`. The tooltip itself is also hoverable/focusable so users can interact with it.
+
 ## Usage within a header
 
 It's often common to provide popover-using UIs in site headers, such as a settings menu, or navigation.

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -188,7 +188,7 @@ const settings = cell(false);
         </button>
 
         {{#if settings.current}}
-          <p.Content open class="floatybit">
+          <p.Content @as="dialog" class="floatybit">
 
             <ul>
               <li>a</li>
@@ -354,8 +354,8 @@ The `<Popover>` component now uses the browser's [Popover API](https://developer
 You no longer need `<PortalTargets />` in your templates. The Popover API promotes floating content to the browser's top layer natively.
 
 ```diff
-- import { PortalTargets, Popover } from 'ember-primitives';
-+ import { Popover } from 'ember-primitives';
+- import { PortalTargets, Popover } from 'ember-primitives/components/popover';
++ import { Popover } from 'ember-primitives/components/popover';
 
   <template>
 -   <PortalTargets />
@@ -377,7 +377,7 @@ The `@inline` argument has been removed. All popover content now renders inline 
 
 ### CSS considerations
 
-The Popover API adds some default styles to `[popover]` elements (`border`, `padding`, `overflow`). The component resets `overflow: visible` automatically so arrows aren't clipped, but you may need to set `border: none` on your floating content if you don't want the default border:
+The browser's `[popover]` UA stylesheet adds default `border`, `padding`, and `overflow` styles to popover elements. The component resets `overflow: visible` automatically so arrows aren't clipped, but you may need to set `border: none` on your floating content if you don't want the browser's default border:
 
 ```css
 .my-popover-content {

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -91,7 +91,7 @@ import { Popover } from "ember-primitives";
       Submit
     </button>
 
-    <p.Content @as="dialog" class="tooltip">
+    <p.Content class="tooltip">
       You must fill out all required fields before submitting.
       <div class="arrow" {{p.arrow}}></div>
     </p.Content>

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -116,7 +116,7 @@ const settings = cell(false);
                 <Popover @placement="left" @offsetOptions={{16}} as |pp|>
                   <button {{pp.reference}}>view profile</button>
 
-                  <pp.Content class="floatybit">
+                  <pp.Content @as="dialog" class="floatybit">
                     View or edit your profile settings
                     <div class="arrow" {{pp.arrow}}></div>
                   </pp.Content>

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -182,7 +182,7 @@ const settings = cell(false);
         </button>
 
         {{#if settings.current}}
-          <p.Content @as="dialog" open class="floatybit">
+          <p.Content open class="floatybit">
 
             <ul>
               <li>a</li>
@@ -194,7 +194,7 @@ const settings = cell(false);
                 <Popover @placement="left" @offsetOptions={{16}} as |pp|>
                   <button {{pp.reference}}>view profile</button>
 
-                  <pp.Content @as="dialog" class="floatybit">
+                  <pp.Content class="floatybit">
                     View or edit your profile settings
                     <div class="arrow" {{pp.arrow}}></div>
                   </pp.Content>

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -378,7 +378,7 @@ The `@inline` argument has been removed. All popover content now renders inline 
 
 ### CSS considerations
 
-The browser's `[popover]` UA stylesheet adds default `border`, `padding`, and `overflow` styles to popover elements. The component resets `overflow: visible` automatically so arrows aren't clipped, but you may need to set `border: none` on your floating content if you don't want the browser's default border:
+The `popover` HTML attribute has a browser UA stylesheet that adds default `border`, `padding`, and `overflow` styles to elements with `[popover]`. The component resets `overflow: visible` automatically so arrows aren't clipped, but you may need to set `border: none` on your floating content if you don't want the browser's default `[popover]` border:
 
 ```css
 .my-popover-content {

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -354,7 +354,8 @@ The `<Popover>` component now uses the browser's [Popover API](https://developer
 You no longer need `<PortalTargets />` in your templates. The Popover API promotes floating content to the browser's top layer natively.
 
 ```diff
-- import { PortalTargets, Popover } from 'ember-primitives/components/popover';
+- import { PortalTargets } from 'ember-primitives/components/portal-targets';
+- import { Popover } from 'ember-primitives/components/popover';
 + import { Popover } from 'ember-primitives/components/popover';
 
   <template>

--- a/ember-primitives/src/components/menu.gts
+++ b/ember-primitives/src/components/menu.gts
@@ -152,13 +152,19 @@ const installContent = eModifier<{
     };
   };
 }>((element, _: [], { isOpen, triggerElement }) => {
-  // focus first focusable element on the content
-  const tabster = getTabster(window);
-  const firstFocusable = tabster?.focusable.findFirst({
-    container: element,
-  });
+  // Focus first focusable element on the content.
+  // Deferred via microtask so the popover API's showPopover()
+  // runs first, ensuring the element is in the top layer.
+  void Promise.resolve().then(() => {
+    if (!element.isConnected) return;
 
-  firstFocusable?.focus();
+    const tabster = getTabster(window);
+    const firstFocusable = tabster?.focusable.findFirst({
+      container: element,
+    });
+
+    firstFocusable?.focus();
+  });
 
   // listen for "outside" clicks
   function onDocumentClick(e: MouseEvent) {

--- a/ember-primitives/src/components/menu.gts
+++ b/ember-primitives/src/components/menu.gts
@@ -154,6 +154,7 @@ const installContent = eModifier<{
 }>((element, _: [], { isOpen, triggerElement }) => {
   // Focus first focusable element when the popover opens.
   // The toggle event fires natively after showPopover() completes.
+  // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/toggle_event
   function onToggle(e: ToggleEvent) {
     if (e.newState !== "open") return;
 

--- a/ember-primitives/src/components/menu.gts
+++ b/ember-primitives/src/components/menu.gts
@@ -152,11 +152,10 @@ const installContent = eModifier<{
     };
   };
 }>((element, _: [], { isOpen, triggerElement }) => {
-  // Focus first focusable element on the content.
-  // Deferred via microtask so the popover API's showPopover()
-  // runs first, ensuring the element is in the top layer.
-  void Promise.resolve().then(() => {
-    if (!element.isConnected) return;
+  // Focus first focusable element when the popover opens.
+  // The toggle event fires natively after showPopover() completes.
+  function onToggle(e: ToggleEvent) {
+    if (e.newState !== "open") return;
 
     const tabster = getTabster(window);
     const firstFocusable = tabster?.focusable.findFirst({
@@ -164,7 +163,9 @@ const installContent = eModifier<{
     });
 
     firstFocusable?.focus();
-  });
+  }
+
+  element.addEventListener("toggle", onToggle as EventListener);
 
   // listen for "outside" clicks
   function onDocumentClick(e: MouseEvent) {
@@ -189,6 +190,7 @@ const installContent = eModifier<{
   document.addEventListener("keydown", onDocumentKeydown);
 
   return () => {
+    element.removeEventListener("toggle", onToggle as EventListener);
     document.removeEventListener("click", onDocumentClick);
     document.removeEventListener("keydown", onDocumentKeydown);
   };

--- a/ember-primitives/src/components/menu.gts
+++ b/ember-primitives/src/components/menu.gts
@@ -336,7 +336,6 @@ export class Menu extends Component<Signature> {
         @placement={{@placement}}
         @shiftOptions={{@shiftOptions}}
         @strategy={{@strategy}}
-        @inline={{@inline}}
         as |p|
       >
         {{#let

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -80,11 +80,15 @@ function getElementTag(tagName: undefined | string) {
 }
 
 const showPopover = eModifier<{ Element: Element }>((element) => {
-  (element as HTMLElement).showPopover();
+  const el = element as HTMLElement;
+
+  // Reset [popover] UA overflow default that clips arrows positioned outside
+  el.style.setProperty("overflow", "visible");
+  el.showPopover();
 
   return () => {
     try {
-      (element as HTMLElement).hidePopover();
+      el.hidePopover();
     } catch {
       /* already hidden */
     }

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -86,6 +86,12 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
   // stacking issues where the parent renders on top of the child.
   if (el.parentElement?.closest("[popover]")) {
     el.removeAttribute("popover");
+
+    // <dialog> elements are hidden by default — ensure they're visible
+    // when opting out of the top layer.
+    if (el instanceof HTMLDialogElement) {
+      el.setAttribute("open", "");
+    }
   } else {
     el.showPopover();
 

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -94,26 +94,6 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
     }
   } else {
     el.showPopover();
-
-    // If the element is focusable (e.g. Menu content with tabindex),
-    // move focus into the first focusable child after entering the
-    // top layer. This is needed because the top layer doesn't
-    // automatically receive focus like portaled content did.
-    if (el.hasAttribute("tabindex")) {
-      requestAnimationFrame(() => {
-        if (!el.isConnected) return;
-
-        const firstFocusable = el.querySelector<HTMLElement>(
-          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-        );
-
-        if (firstFocusable) {
-          firstFocusable.focus();
-        } else {
-          el.focus();
-        }
-      });
-    }
   }
 
   return () => {

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -84,13 +84,7 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
   // popover already handles layering. Adding both to the top layer causes
   // stacking issues where the parent renders on top of the child.
   if (el.parentElement?.closest("[popover]")) {
-    // Nested inside another popover — don't add to top layer separately.
-    // Remove popover attr and ensure element is visible.
     el.removeAttribute("popover");
-
-    if (el instanceof HTMLDialogElement) {
-      el.setAttribute("open", "");
-    }
   } else {
     el.showPopover();
   }
@@ -105,25 +99,21 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
 });
 
 /**
- * Content uses `<dialog popover="manual">` + `showPopover()` to promote
+ * Content uses `popover="manual"` + `showPopover()` to promote
  * the element to the browser's top layer. This escapes all ancestor
  * overflow clipping and stacking contexts — the same guarantee that
  * portalling provided, but using the browser's native mechanism.
- *
- * We use `<dialog>` rather than `<div>` so that nested popovers
- * (which opt out of the top layer) can fall back to `<dialog open>`
- * and remain visible without JS.
  */
 const Content: TOC<{
-  Element: HTMLDialogElement;
+  Element: HTMLDivElement;
   Args: {
     floating: ModifierLike<{ Element: HTMLElement }>;
   };
   Blocks: { default: [] };
 }> = <template>
-  <dialog popover="manual" role="none" {{showPopover}} {{@floating}} ...attributes>
+  <div popover="manual" {{showPopover}} {{@floating}} ...attributes>
     {{yield}}
-  </dialog>
+  </div>
 </template>;
 
 interface AttachArrowSignature {

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -88,6 +88,12 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
     el.removeAttribute("popover");
   } else {
     el.showPopover();
+
+    // If the element is focusable (e.g. Menu content with tabindex),
+    // move focus into it after entering the top layer.
+    if (el.hasAttribute("tabindex")) {
+      el.focus();
+    }
   }
 
   return () => {

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -1,4 +1,5 @@
 import { hash } from "@ember/helper";
+import { schedule } from "@ember/runloop";
 
 import { arrow } from "@floating-ui/dom";
 import { element } from "ember-element-helper";
@@ -96,9 +97,23 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
     el.showPopover();
 
     // If the element is focusable (e.g. Menu content with tabindex),
-    // move focus into it after entering the top layer.
+    // move focus into the first focusable child after entering the
+    // top layer. This is needed because the top layer doesn't
+    // automatically receive focus like portaled content did.
+    // Uses afterRender so Ember's test helpers (await click, etc.)
+    // wait for this to complete.
     if (el.hasAttribute("tabindex")) {
-      el.focus();
+      schedule("afterRender", () => {
+        const firstFocusable = el.querySelector<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+
+        if (firstFocusable) {
+          firstFocusable.focus();
+        } else {
+          el.focus();
+        }
+      });
     }
   }
 

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -84,7 +84,20 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
 
   // Reset [popover] UA overflow default that clips arrows positioned outside
   el.style.setProperty("overflow", "visible");
-  el.showPopover();
+
+  // Don't promote to top layer if already inside a popover — the parent
+  // popover already handles layering. Adding both to the top layer causes
+  // stacking issues where the parent renders on top of the child.
+  if (el.parentElement?.closest("[popover]")) {
+    // Nested inside another popover — don't add to top layer separately.
+    // Remove popover attr and ensure element is visible.
+    el.removeAttribute("popover");
+    if (el instanceof HTMLDialogElement) {
+      el.setAttribute("open", "");
+    }
+  } else {
+    el.showPopover();
+  }
 
   return () => {
     try {

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -87,6 +87,7 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
     // Nested inside another popover — don't add to top layer separately.
     // Remove popover attr and ensure element is visible.
     el.removeAttribute("popover");
+
     if (el instanceof HTMLDialogElement) {
       el.setAttribute("open", "");
     }

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -1,6 +1,7 @@
 import { hash } from "@ember/helper";
 
 import { arrow } from "@floating-ui/dom";
+import { element } from "ember-element-helper";
 import { modifier as eModifier } from "ember-modifier";
 import { cell } from "ember-resources";
 
@@ -98,6 +99,10 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
   };
 });
 
+function getElementTag(tagName: undefined | string) {
+  return tagName || "div";
+}
+
 /**
  * Content uses `popover="manual"` + `showPopover()` to promote
  * the element to the browser's top layer. This escapes all ancestor
@@ -108,12 +113,32 @@ const Content: TOC<{
   Element: HTMLDivElement;
   Args: {
     floating: ModifierLike<{ Element: HTMLElement }>;
+    /**
+     * By default the popover content is wrapped in a div.
+     * You may change this by supplying the name of an element here.
+     *
+     * For example:
+     * ```gjs
+     * <Popover as |p|>
+     *  <p.Content @as="dialog">
+     *    this is now focus trapped
+     *  </p.Content>
+     * </Popover>
+     * ```
+     */
+    as?: string;
   };
   Blocks: { default: [] };
 }> = <template>
-  <div popover="manual" {{showPopover}} {{@floating}} ...attributes>
-    {{yield}}
-  </div>
+  {{#let (element (getElementTag @as)) as |El|}}
+    {{! @glint-ignore
+          https://github.com/tildeio/ember-element-helper/issues/91
+          https://github.com/typed-ember/glint/issues/610
+    }}
+    <El popover="manual" {{showPopover}} {{@floating}} ...attributes>
+      {{yield}}
+    </El>
+  {{/let}}
 </template>;
 
 interface AttachArrowSignature {

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -6,8 +6,6 @@ import { modifier as eModifier } from "ember-modifier";
 import { cell } from "ember-resources";
 
 import { FloatingUI } from "../floating-ui.ts";
-import { Portal } from "./portal.gts";
-import { TARGETS } from "./portal-targets.gts";
 
 import type { Signature as FloatingUiComponentSignature } from "../floating-ui/component.ts";
 import type { Signature as HookSignature } from "../floating-ui/modifier.ts";
@@ -63,15 +61,6 @@ export interface Signature {
      * This argument is forwarded to the `<FloatingUI>` component.
      */
     strategy?: HookSignature["Args"]["Named"]["strategy"];
-
-    /**
-     * By default, the popover is portaled.
-     * If you don't control your CSS, and the positioning of the popover content
-     * is misbehaving, you may pass "@inline={{true}}" to opt out of portalling.
-     *
-     * Inline may also be useful in nested menus, where you know exactly how the nesting occurs
-     */
-    inline?: boolean;
   };
   Blocks: {
     default: [
@@ -90,15 +79,22 @@ function getElementTag(tagName: undefined | string) {
   return tagName || "div";
 }
 
-/**
- * Allows lazy evaluation of the portal target (do nothing until rendered)
- * This is useful because the algorithm for finding the portal target isn't cheap.
- */
+const showPopover = eModifier<{ Element: Element }>((element) => {
+  (element as HTMLElement).showPopover();
+
+  return () => {
+    try {
+      (element as HTMLElement).hidePopover();
+    } catch {
+      /* already hidden */
+    }
+  };
+});
+
 const Content: TOC<{
   Element: HTMLDivElement;
   Args: {
     floating: ModifierLike<{ Element: HTMLElement }>;
-    inline?: boolean;
     /**
      * By default the popover content is wrapped in a div.
      * You may change this by supplying the name of an element here.
@@ -117,25 +113,13 @@ const Content: TOC<{
   Blocks: { default: [] };
 }> = <template>
   {{#let (element (getElementTag @as)) as |El|}}
-    {{#if @inline}}
-      {{! @glint-ignore
-            https://github.com/tildeio/ember-element-helper/issues/91
-            https://github.com/typed-ember/glint/issues/610
-      }}
-      <El {{@floating}} ...attributes>
-        {{yield}}
-      </El>
-    {{else}}
-      <Portal @to={{TARGETS.popover}}>
-        {{! @glint-ignore
-              https://github.com/tildeio/ember-element-helper/issues/91
-              https://github.com/typed-ember/glint/issues/610
-        }}
-        <El {{@floating}} ...attributes>
-          {{yield}}
-        </El>
-      </Portal>
-    {{/if}}
+    {{! @glint-ignore
+          https://github.com/tildeio/ember-element-helper/issues/91
+          https://github.com/typed-ember/glint/issues/610
+    }}
+    <El popover="manual" {{showPopover}} {{@floating}} ...attributes>
+      {{yield}}
+    </El>
   {{/let}}
 </template>;
 
@@ -235,7 +219,7 @@ export const Popover: TOC<Signature> = <template>
           (hash
             reference=reference
             setReference=extra.setReference
-            Content=(component Content floating=floating inline=@inline)
+            Content=(component Content floating=floating)
             data=extra.data
             arrow=arrow
           )

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -1,5 +1,4 @@
 import { hash } from "@ember/helper";
-import { schedule } from "@ember/runloop";
 
 import { arrow } from "@floating-ui/dom";
 import { element } from "ember-element-helper";
@@ -100,10 +99,10 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
     // move focus into the first focusable child after entering the
     // top layer. This is needed because the top layer doesn't
     // automatically receive focus like portaled content did.
-    // Uses afterRender so Ember's test helpers (await click, etc.)
-    // wait for this to complete.
     if (el.hasAttribute("tabindex")) {
-      schedule("afterRender", () => {
+      requestAnimationFrame(() => {
+        if (!el.isConnected) return;
+
         const firstFocusable = el.querySelector<HTMLElement>(
           'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
         );

--- a/ember-primitives/src/components/popover.gts
+++ b/ember-primitives/src/components/popover.gts
@@ -1,7 +1,6 @@
 import { hash } from "@ember/helper";
 
 import { arrow } from "@floating-ui/dom";
-import { element } from "ember-element-helper";
 import { modifier as eModifier } from "ember-modifier";
 import { cell } from "ember-resources";
 
@@ -75,10 +74,6 @@ export interface Signature {
   };
 }
 
-function getElementTag(tagName: undefined | string) {
-  return tagName || "div";
-}
-
 const showPopover = eModifier<{ Element: Element }>((element) => {
   const el = element as HTMLElement;
 
@@ -108,36 +103,26 @@ const showPopover = eModifier<{ Element: Element }>((element) => {
   };
 });
 
+/**
+ * Content uses `<dialog popover="manual">` + `showPopover()` to promote
+ * the element to the browser's top layer. This escapes all ancestor
+ * overflow clipping and stacking contexts — the same guarantee that
+ * portalling provided, but using the browser's native mechanism.
+ *
+ * We use `<dialog>` rather than `<div>` so that nested popovers
+ * (which opt out of the top layer) can fall back to `<dialog open>`
+ * and remain visible without JS.
+ */
 const Content: TOC<{
-  Element: HTMLDivElement;
+  Element: HTMLDialogElement;
   Args: {
     floating: ModifierLike<{ Element: HTMLElement }>;
-    /**
-     * By default the popover content is wrapped in a div.
-     * You may change this by supplying the name of an element here.
-     *
-     * For example:
-     * ```gjs
-     * <Popover as |p|>
-     *  <p.Content @as="dialog">
-     *    this is now focus trapped
-     *  </p.Content>
-     * </Popover>
-     * ```
-     */
-    as?: string;
   };
   Blocks: { default: [] };
 }> = <template>
-  {{#let (element (getElementTag @as)) as |El|}}
-    {{! @glint-ignore
-          https://github.com/tildeio/ember-element-helper/issues/91
-          https://github.com/typed-ember/glint/issues/610
-    }}
-    <El popover="manual" {{showPopover}} {{@floating}} ...attributes>
-      {{yield}}
-    </El>
-  {{/let}}
+  <dialog popover="manual" role="none" {{showPopover}} {{@floating}} ...attributes>
+    {{yield}}
+  </dialog>
 </template>;
 
 interface AttachArrowSignature {


### PR DESCRIPTION
## Summary

- Replaces `<Portal>` + `<PortalTargets>` with the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) (`popover="manual"`) for promoting Content elements to the browser's top layer
- Removes `@inline` arg — no longer needed since the top layer replaces both inline and portaled modes
- Consumers no longer need `<PortalTargets />` in their templates
- **FloatingUI is unchanged** — it still handles all positioning (flip, shift, offset, arrow)

This is a focused change: only the layering mechanism changes (portals → popover API). Positioning stays the same.

Closes #265

## Test plan

- [x] First demo: popover renders above anchor, follows on scroll, not clipped by overflow
- [x] Second demo: settings dropdown and nested "view profile" popover both render in top layer, not clipped
- [x] Build passes
- [x] Verified in headless Chrome via Puppeteer

🤖 Generated with [Claude Code](https://claude.com/claude-code)