### PR TITLE
Update tracked-toolbox to v3

### DIFF
--- a/ember-primitives/package.json
+++ b/ember-primitives/package.json
@@ -44,7 +44,7 @@
     "should-handle-link": "^1.2.2",
     "tabster": "^8.7.0",
     "tracked-built-ins": "^4.1.0",
-    "tracked-toolbox": "^2.2.0",
+    "tracked-toolbox": "^3.0.0",
     "which-heading-do-i-need": "workspace:*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
       "ember-repl": "^8.0.0",
       "ember-source": "^6.10.1",
       "reactiveweb": "^1.9.1",
-      "tracked-toolbox": "^2.2.0"
+      "tracked-toolbox": "^3.0.0"
     },
     "patchedDependencies": {},
     "packageExtensions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ overrides:
   ember-repl: ^8.0.0
   ember-source: ^6.10.1
   reactiveweb: ^1.9.1
-  tracked-toolbox: ^2.2.0
+  tracked-toolbox: ^3.0.0
 
 packageExtensionsChecksum: sha256-p0kU58WxiwX1+oCFC0kx9iAdkYUX2HD1bCOkKzPWl04=
 
@@ -322,8 +322,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.2(@babel/core@7.29.0)
       tracked-toolbox:
-        specifier: ^2.2.0
-        version: 2.2.0(@babel/core@7.29.0)
+        specifier: ^3.0.0
+        version: 3.0.0(@babel/core@7.29.0)
       which-heading-do-i-need:
         specifier: workspace:*
         version: link:../packages/which-heading-do-i-need
@@ -3013,12 +3013,6 @@ packages:
     resolution: {integrity: sha512-2copPaWQFUrzooJVIVZA/Oppx/S/KOoZ4Uhr+XWEQDMZ8Rvq/0SNQpbdIyMBJ8IELWt10dewuJw+tX4XjOo7Rg==}
     engines: {node: '>= 12.*'}
 
-  babel-plugin-debug-macros@0.2.0:
-    resolution: {integrity: sha512-Wpmw4TbhR3Eq2t3W51eBAQSdKlr+uAyF0GI4GtPfMCD12Y4cIdpKC9l0RjNTH/P9isFypSqqewMPm7//fnZlNA==}
-    engines: {node: '>=4'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-beta.42
-
   babel-plugin-debug-macros@0.3.4:
     resolution: {integrity: sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==}
     engines: {node: '>=6'}
@@ -3819,10 +3813,6 @@ packages:
       qunit:
         optional: true
 
-  ember-cache-primitive-polyfill@1.0.1:
-    resolution: {integrity: sha512-hSPcvIKarA8wad2/b6jDd/eU+OtKmi6uP+iYQbzi5TQpjsqV6b4QdRqrLk7ClSRRKBAtdTuutx+m+X+WlEd2lw==}
-    engines: {node: 10.* || >= 12}
-
   ember-cli-babel-plugin-helpers@1.1.1:
     resolution: {integrity: sha512-sKvOiPNHr5F/60NLd7SFzMpYPte/nnGkq/tMIfXejfKHIhaiIkYFqX8Z9UFTKWLLn+V7NOaby6niNPZUdvKCRw==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3853,10 +3843,6 @@ packages:
 
   ember-cli-version-checker@5.1.2:
     resolution: {integrity: sha512-rk7GY+FmLn/2e22HsZs0Ycrz8HQ1W3Fv+2TFOuEFW9optnDXDgkntPBIl6gact/LHsfBM5RKbM3dHsIIeLgl0Q==}
-    engines: {node: 10.* || >= 12.*}
-
-  ember-compatibility-helpers@1.2.7:
-    resolution: {integrity: sha512-BtkjulweiXo9c3yVWrtexw2dTmBrvavD/xixNC6TKOBdrixUwU+6nuOO9dufDWsMxoid7MvtmDpzc9+mE8PdaA==}
     engines: {node: 10.* || >= 12.*}
 
   ember-concurrency@5.2.0:
@@ -7079,8 +7065,8 @@ packages:
   tracked-built-ins@4.1.2:
     resolution: {integrity: sha512-KiiV/Pzi7VNKTn9Fip6Ic54AjKgFfqows1Jq3L0WLVqZcvfswdhVxQ9yqqhTXsmgLhVzIgtdzNBH4ExqWf34BQ==}
 
-  tracked-toolbox@2.2.0:
-    resolution: {integrity: sha512-YknotXj74U0nCqBk9nh1Uv1IWTnVOgt8sXIecNkyEq4oFOU70niQUlozO4E3kMKx7ae/rNlOtoF+1ALcHYzCrQ==}
+  tracked-toolbox@3.0.0:
+    resolution: {integrity: sha512-9Q5SH+0jevfB07oL2bsjxIDv0jQ2A6IgminkvnMMzGLc2EqCFm/yKuqNeUFvN3n+TOAQk+PZcePtIaxIo/1now==}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -10452,11 +10438,6 @@ snapshots:
 
   babel-import-util@3.0.1: {}
 
-  babel-plugin-debug-macros@0.2.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      semver: 5.7.2
-
   babel-plugin-debug-macros@0.3.4(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -11280,16 +11261,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-cache-primitive-polyfill@1.0.1(@babel/core@7.29.0):
-    dependencies:
-      ember-cli-babel: 8.3.1(@babel/core@7.29.0)
-      ember-cli-version-checker: 5.1.2
-      ember-compatibility-helpers: 1.2.7(@babel/core@7.29.0)
-      silent-error: 1.1.1
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   ember-cli-babel-plugin-helpers@1.1.1: {}
 
   ember-cli-babel@8.3.1(@babel/core@7.29.0):
@@ -11352,17 +11323,6 @@ snapshots:
       semver: 7.7.4
       silent-error: 1.1.1
     transitivePeerDependencies:
-      - supports-color
-
-  ember-compatibility-helpers@1.2.7(@babel/core@7.29.0):
-    dependencies:
-      babel-plugin-debug-macros: 0.2.0(@babel/core@7.29.0)
-      ember-cli-version-checker: 5.1.2
-      find-up: 5.0.0
-      fs-extra: 9.1.0
-      semver: 5.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
       - supports-color
 
   ember-concurrency@5.2.0(c8332dc3f90c0e60eb130a3a85f980b9):
@@ -11496,7 +11456,7 @@ snapshots:
       should-handle-link: 1.3.0
       tabster: 8.7.0
       tracked-built-ins: 4.1.2(@babel/core@7.29.0)
-      tracked-toolbox: 2.2.0(@babel/core@7.29.0)
+      tracked-toolbox: 3.0.0(@babel/core@7.29.0)
       which-heading-do-i-need: file:packages/which-heading-do-i-need
     optionalDependencies:
       '@ember/test-helpers': 5.4.1(c8332dc3f90c0e60eb130a3a85f980b9)
@@ -15544,11 +15504,10 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  tracked-toolbox@2.2.0(@babel/core@7.29.0):
+  tracked-toolbox@3.0.0(@babel/core@7.29.0):
     dependencies:
       '@embroider/addon-shim': 1.10.2
       decorator-transforms: 2.3.1(@babel/core@7.29.0)
-      ember-cache-primitive-polyfill: 1.0.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color


### PR DESCRIPTION
## Summary
- Bumps `tracked-toolbox` from `^2.2.0` to `^3.0.0` in both the workspace `pnpm.overrides` and `ember-primitives/package.json`.
- v3's only breaking change is removing the `ember-cache-primitive-polyfill` dependency ([tracked-tools/tracked-toolbox#246](https://github.com/tracked-tools/tracked-toolbox/pull/246)). No public API changes.

## Test plan
- [ ] CI passes (lint, types, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)