### PR TITLE
color-scheme: also mirror onto a data-color-scheme attribute

### DIFF
--- a/docs-app/app/templates/6-utils/color-scheme.gjs.md
+++ b/docs-app/app/templates/6-utils/color-scheme.gjs.md
@@ -11,6 +11,16 @@ However, when using prefers-color-scheme, there are some rough edges around the 
 
 So, we need to run some JavaScript to synchronize all this.
 
+`setColorScheme` (and the `colorScheme.update` setter that calls it) writes the value as both an inline `style="color-scheme: …"` declaration _and_ a `data-color-scheme="…"` attribute on the same element, so authors can target it directly from CSS:
+
+```css
+:root[data-color-scheme='dark'] {
+  --bg: #151515;
+}
+```
+
+The attribute-based selector is also the recommended pattern when your CSS pipeline is lightning-css (Vite's default since v5). lightning-css doesn't reliably resolve the `light-dark()` CSS function, so variables defined as `--bg: light-dark(#fff, #151515)` can come through computed-empty; selecting on `:root[data-color-scheme='dark']` and assigning literal values side-steps the issue.
+
 [mdn-prefers-color-scheme]: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
 [mdn-color-scheme]: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme 
 

--- a/ember-primitives/src/color-scheme.ts
+++ b/ember-primitives/src/color-scheme.ts
@@ -141,6 +141,19 @@ export const localPreference = {
 };
 
 /**
+ * The attribute name mirrored alongside the inline `color-scheme`
+ * style. Inline-style declarations aren't selectable from CSS, so we
+ * also write the value to a plain HTML attribute that authors can
+ * target with selectors like `:root[data-color-scheme='dark']`.
+ *
+ * Some CSS pipelines (notably lightning-css, which Vite uses by
+ * default) don't reliably resolve the `light-dark()` function — any
+ * variables defined with it can come through computed-empty. Selecting
+ * on this attribute side-steps that whole class of issue.
+ */
+export const COLOR_SCHEME_ATTRIBUTE = 'data-color-scheme';
+
+/**
  * For the given element, returns the `color-scheme` of that element.
  */
 export function getColorScheme(element?: HTMLElement) {
@@ -154,13 +167,13 @@ export function setColorScheme(value: string): void;
 
 export function setColorScheme(...args: [string] | [HTMLElement, string]): void {
   if (typeof args[0] === 'string') {
-    styleOf().setProperty('color-scheme', args[0]);
+    apply(elementOf(), args[0]);
 
     return;
   }
 
   if (typeof args[1] === 'string') {
-    styleOf(args[0]).setProperty('color-scheme', args[1]);
+    apply(args[0], args[1]);
 
     return;
   }
@@ -172,17 +185,23 @@ export function setColorScheme(...args: [string] | [HTMLElement, string]): void 
  * Removes the `color-scheme` from the given element
  */
 export function removeColorScheme(element?: HTMLElement) {
-  const style = styleOf(element);
+  const el = elementOf(element);
 
-  style.removeProperty('color-scheme');
+  el.style.removeProperty('color-scheme');
+  el.removeAttribute(COLOR_SCHEME_ATTRIBUTE);
+}
+
+function apply(element: HTMLElement, value: string) {
+  element.style.setProperty('color-scheme', value);
+  element.setAttribute(COLOR_SCHEME_ATTRIBUTE, value);
 }
 
 function styleOf(element?: HTMLElement) {
-  if (element) {
-    return element.style;
-  }
+  return elementOf(element).style;
+}
 
-  return document.documentElement.style;
+function elementOf(element?: HTMLElement): HTMLElement {
+  return element ?? document.documentElement;
 }
 
 sync();

--- a/test-app/tests/color-scheme/color-scheme-rendering-test.gts
+++ b/test-app/tests/color-scheme/color-scheme-rendering-test.gts
@@ -3,6 +3,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
 import {
+  COLOR_SCHEME_ATTRIBUTE,
   colorScheme,
   getColorScheme,
   localPreference,
@@ -55,29 +56,54 @@ module('color-scheme', function (hooks) {
   });
 
   test('get/set/remove ColorScheme', function (assert) {
+    const root = document.documentElement;
+
     setColorScheme('synthwave');
     assert.strictEqual(getColorScheme(), 'synthwave');
+    assert.strictEqual(
+      root.getAttribute(COLOR_SCHEME_ATTRIBUTE),
+      'synthwave',
+      'mirrors onto data attribute'
+    );
 
     setColorScheme('dark');
     assert.strictEqual(getColorScheme(), 'dark');
+    assert.strictEqual(root.getAttribute(COLOR_SCHEME_ATTRIBUTE), 'dark');
 
     removeColorScheme();
     assert.strictEqual(getColorScheme(), '');
+    assert.strictEqual(
+      root.getAttribute(COLOR_SCHEME_ATTRIBUTE),
+      null,
+      'attribute is cleared on remove'
+    );
   });
 
   test('get/set/remove ColorScheme on an element', function (assert) {
     const el = document.createElement('div');
 
     assert.strictEqual(getColorScheme(el), '');
+    assert.strictEqual(el.getAttribute(COLOR_SCHEME_ATTRIBUTE), null);
 
     setColorScheme(el, 'synthwave');
     assert.strictEqual(getColorScheme(el), 'synthwave');
+    assert.strictEqual(
+      el.getAttribute(COLOR_SCHEME_ATTRIBUTE),
+      'synthwave',
+      'mirrors onto element data attribute'
+    );
 
     setColorScheme(el, 'dark');
     assert.strictEqual(getColorScheme(el), 'dark');
+    assert.strictEqual(el.getAttribute(COLOR_SCHEME_ATTRIBUTE), 'dark');
 
     removeColorScheme(el);
     assert.strictEqual(getColorScheme(el), '');
+    assert.strictEqual(
+      el.getAttribute(COLOR_SCHEME_ATTRIBUTE),
+      null,
+      'attribute is cleared on remove'
+    );
   });
 
   test('localPreference', function (assert) {


### PR DESCRIPTION
## Summary

`setColorScheme(value)` writes an inline `style=\"color-scheme: …\"` declaration. CSS selectors can't target inline-style declarations, so authors who want a CSS hook for the active theme (`:root[…='dark'] { … }`) have to write their own JS-driven mirror. The docs even document this with a `syncBodyClass` snippet, and every consumer ends up re-implementing the same effect.

This PR has `setColorScheme` (and `removeColorScheme`) also mirror the value onto a `data-color-scheme` attribute on the same element, exported as `COLOR_SCHEME_ATTRIBUTE` for programmatic access. Authors get a plain selector target without writing any JS:

\`\`\`css
:root[data-color-scheme='dark'] {
  --bg: #151515;
  --fg: #efefef;
}
\`\`\`

It's also the cross-pipeline-safe pattern when the CSS toolchain is lightning-css (Vite's default since v5), where `light-dark()` doesn't reliably resolve and variables defined with it can come through computed-empty. The docs page gains a short note flagging this so the next person hitting it has somewhere to land.

## Changes

- `ember-primitives/src/color-scheme.ts`
  - Export `COLOR_SCHEME_ATTRIBUTE = 'data-color-scheme'`.
  - `setColorScheme(value)` and `setColorScheme(element, value)` set the attribute alongside the inline style.
  - `removeColorScheme(element?)` clears both.
  - Refactor of the helpers (`apply`, `elementOf`) to keep the two paths in lockstep.
- `test-app/tests/color-scheme/color-scheme-rendering-test.gts` — assertions that the attribute is set/cleared on both `documentElement` and an explicit element.
- `docs-app/app/templates/6-utils/color-scheme.gjs.md` — paragraph describing the new attribute and the lightning-css caveat.

## Test plan

- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm test:ember` — all 8 color-scheme tests pass (the 4 failures in the suite are pre-existing `<InViewport />` flakes unrelated to this PR)

## Compatibility

Strictly additive — existing consumers reading `getColorScheme()` or styling on the inline `color-scheme` value continue to work. New consumers can opt into the attribute selector at any time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)