### PR TITLE
Polyfill requestIdleCallback for Safari

### DIFF
--- a/ember-primitives/src/components/incremental-each.gts
+++ b/ember-primitives/src/components/incremental-each.gts
@@ -23,6 +23,15 @@ function chunk<T>(arr: readonly T[], size: number): T[][] {
   return out;
 }
 
+// Safari has `requestIdleCallback` behind a flag, effectively absent
+// for end users. Fall back to `setTimeout(cb, 0)` — Safari users get
+// the chunking benefit (one batch per task) without the idle-priority
+// hint that other browsers honor.
+const ric: typeof requestIdleCallback =
+  typeof requestIdleCallback === "function"
+    ? requestIdleCallback
+    : (cb) => setTimeout(() => cb({ timeRemaining: () => 0, didTimeout: true }), 0);
+
 export interface Signature<T = unknown> {
   Args: {
     /**
@@ -261,7 +270,7 @@ export class IncrementalEach<T = unknown> extends Component<Signature<T>> {
   // otherwise tracked-value backtracking asserts.
   tick = () => {
     if (this.#items.length > this.#count.current) {
-      requestIdleCallback(() => this.#count.current++, { timeout: 10 });
+      ric(() => this.#count.current++, { timeout: 10 });
     }
   };
 


### PR DESCRIPTION
Follow-up to #743 / #744.

Safari ships [`requestIdleCallback` behind a feature flag](https://caniuse.com/requestidlecallback), so it's effectively absent for end users on both desktop and iOS. Without a fallback, `IncrementalEach` throws `requestIdleCallback is not a function` on its first tick in Safari.

Fall back to `setTimeout(cb, 0)`. Safari users still get the chunking benefit (one batch per task drain) — just without the idle-priority hint Chromium and Firefox honor.

```ts
const ric: typeof requestIdleCallback =
  typeof requestIdleCallback === "function"
    ? requestIdleCallback
    : (cb) => setTimeout(() => cb({ timeRemaining: () => 0, didTimeout: true }), 0);
```

## Test plan
- [x] `pnpm ember-tsc --noEmit` clean
- [x] `pnpm --filter ember-primitives build` succeeds
- [x] `pnpm lint` passes
- [x] All 13 IncrementalEach tests pass locally
- [ ] Verify in Safari that the demo page renders (not feasible from this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)