### PR TITLE
Add eslint-plugin-compat to lint addon source against supported browsers

### DIFF
--- a/ember-primitives/eslint.config.mjs
+++ b/ember-primitives/eslint.config.mjs
@@ -1,10 +1,15 @@
 // eslint.config.js
 import { configs } from "@nullvoxpopuli/eslint-configs";
+import compat from "eslint-plugin-compat";
 
 const config = configs.ember(import.meta.dirname);
 
 export default [
   ...config,
+  {
+    ...compat.configs["flat/recommended"],
+    files: ["src/**/*.{js,ts,gjs,gts}"],
+  },
   {
     files: ["./src/components/toggle-group.gts"],
     rules: {

--- a/ember-primitives/package.json
+++ b/ember-primitives/package.json
@@ -78,6 +78,7 @@
     "ember-source": "^6.10.1",
     "ember-template-lint": "^7.9.3",
     "eslint": "^9.39.2",
+    "eslint-plugin-compat": "^7.0.2",
     "execa": "^9.6.0",
     "fix-bad-declaration-output": "^1.1.5",
     "prettier": "^3.8.1",
@@ -138,6 +139,12 @@
     "ember-modifier": ">= 4.1.0",
     "ember-resources": ">= 6.1.0"
   },
+  "browserslist": [
+    "last 2 Chrome versions",
+    "last 2 Firefox versions",
+    "last 2 Safari versions",
+    "last 2 Edge versions"
+  ],
   "peerDependenciesMeta": {
     "@ember/test-helpers": {
       "optional": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.6.1)
+      eslint-plugin-compat:
+        specifier: ^7.0.2
+        version: 7.0.2(eslint@9.39.4(jiti@2.6.1))
       execa:
         specifier: ^9.6.0
         version: 9.6.1
@@ -2026,6 +2029,12 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@mdn/browser-compat-data@5.7.6':
+    resolution: {integrity: sha512-7xdrMX0Wk7grrTZQwAoy1GkvPMFoizStUoL+VmtUkAxegbCCec+3FKwOM6yc/uGU5+BEczQHXAlWiqvM8JeENg==}
+
+  '@mdn/browser-compat-data@6.1.5':
+    resolution: {integrity: sha512-PzdZZzRhcXvKB0begee28n5lvwAcinGKYuLZOVxHAZm+n7y01ddEGfdS1ZXRuVcV+ndG6mSEAE8vgudom5UjYg==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2954,6 +2963,9 @@ packages:
 
   assert@2.1.0:
     resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
+  ast-metadata-inferer@0.8.1:
+    resolution: {integrity: sha512-ht3Dm6Zr7SXv6t1Ra6gFo0+kLDglHGrEbYihTkcycrbHw7WCcuhBzPlJYHEsIpycaUwzsJHje+vUcxXUX4ztTA==}
 
   ast-types@0.13.3:
     resolution: {integrity: sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==}
@@ -4170,6 +4182,12 @@ packages:
         optional: true
       eslint-import-resolver-webpack:
         optional: true
+
+  eslint-plugin-compat@7.0.2:
+    resolution: {integrity: sha512-gN8hF+4NzMsHUbr4m/TYZK0FtW3DcV4g8rXpTsY2EV5xiRD8jsilUlB9lNSkGGX0veDCxMhKSWbSd+faJByQDA==}
+    engines: {node: '>=22.x'}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
 
   eslint-plugin-decorator-position@6.1.0:
     resolution: {integrity: sha512-UsxMoWwnFxBwWwyyHIhHbg5vNixU3lu+EGPX0gXFSNLomImFihfulHR/tjBllqAE+NPXGZ+yJpVfE4hcbBQsmg==}
@@ -5389,6 +5407,9 @@ packages:
 
   lodash.kebabcase@4.1.1:
     resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
+  lodash.memoize@4.1.2:
+    resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -9430,6 +9451,10 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@mdn/browser-compat-data@5.7.6': {}
+
+  '@mdn/browser-compat-data@6.1.5': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -10328,6 +10353,10 @@ snapshots:
       object-is: 1.1.6
       object.assign: 4.1.7
       util: 0.12.5
+
+  ast-metadata-inferer@0.8.1:
+    dependencies:
+      '@mdn/browser-compat-data': 5.7.6
 
   ast-types@0.13.3: {}
 
@@ -11774,6 +11803,17 @@ snapshots:
       eslint-import-resolver-typescript: 4.4.4(3ee4a70ccc9e8a5afe5f56d747a64d9a)
     transitivePeerDependencies:
       - supports-color
+
+  eslint-plugin-compat@7.0.2(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      '@mdn/browser-compat-data': 6.1.5
+      ast-metadata-inferer: 0.8.1
+      browserslist: 4.28.2
+      eslint: 9.39.4(jiti@2.6.1)
+      find-up: 5.0.0
+      globals: 15.15.0
+      lodash.memoize: 4.1.2
+      semver: 7.7.4
 
   eslint-plugin-decorator-position@6.1.0(68368dad875476049095689d4385e150):
     dependencies:
@@ -13255,6 +13295,8 @@ snapshots:
   lodash.debounce@4.0.8: {}
 
   lodash.kebabcase@4.1.1: {}
+
+  lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
 


### PR DESCRIPTION
## Summary
- Adds [`eslint-plugin-compat`](https://github.com/amilajack/eslint-plugin-compat) as a dev dep of the `ember-primitives` addon and wires its `flat/recommended` preset into the addon's flat ESLint config.
- Scopes the rule to `src/**/*.{js,ts,gjs,gts}` so it does not fire on Node-side files (`rollup.config.mjs`, `addon-main.cjs`, the ESLint config itself, etc.).
- Adds a `browserslist` field to `ember-primitives/package.json` so the plugin has explicit targets to compare against:
  ```json
  [
    "last 2 Chrome versions",
    "last 2 Firefox versions",
    "last 2 Safari versions",
    "last 2 Edge versions"
  ]
  ```
  The addon already relies on the Popover API, CSS Anchor Positioning, etc. — these targets cover all of those (Chrome 114+, Firefox 125+, Safari 17+). If you'd rather use a different target string (e.g. `defaults`, ember-cli's default, or something tighter), the only thing that needs to change is this field.

The rule produces no findings against the current addon source on those targets.

## Why
Catches use of browser APIs that aren't supported by the documented target set at lint time rather than discovering them through user bug reports.

## Verification
- `pnpm install` — adds `eslint-plugin-compat@^7.0.2` plus its transitive `@mdn/browser-compat-data` and friends.
- `pnpm --filter ember-primitives lint` — all subtasks (`lint:js`, `lint:prettier`, `lint:types`) pass cleanly. `lint:package` output is unchanged from `main`.
- Confirmed the rule actually fires by temporarily inserting `navigator.serial` into `src/` — produces `compat/compat` errors as expected, then removed.

## Test plan
- [ ] CI passes.
- [ ] Confirm the chosen browserslist target reflects what `ember-primitives` wants to officially support — adjust the four-line entry in `ember-primitives/package.json` if not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)