### PR TITLE
Slider ergonomics: ship the structural CSS with the component

### DIFF
--- a/docs-app/app/templates/3-ui/slider.gjs.md
+++ b/docs-app/app/templates/3-ui/slider.gjs.md
@@ -967,6 +967,10 @@ Each thumb is a native `<input type="range">`, so it gets browser keyboard inter
 
 For accessibility, make sure each thumb has an accessible name. For example, pass `aria-label` / `aria-labelledby` via `...attributes` to `<s.Thumb>`. When no block is given to `<Slider>`, default labels are provided (`Value`, or `Minimum` / `Maximum` for a two-thumb range).
 
+To submit the value as part of a `<form>`, pass a `name` (and optionally `id`) to `<s.Thumb>` the same way -- each thumb is a real form control.
+
+The pointer target of each thumb defaults to 24px (`--ember-primitives__slider__hit-area`), the [WCAG 2.2 minimum target size](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html). Increase the variable for touch-heavy UIs.
+
 ### Keyboard Navigation
 
 Keyboard support is provided by the platform (and can vary slightly by browser/OS).

--- a/docs-app/app/templates/3-ui/slider.gjs.md
+++ b/docs-app/app/templates/3-ui/slider.gjs.md
@@ -32,7 +32,7 @@ All of the structural CSS needed for this technique (positioning, hiding the nat
 Pass an array to `@value` to get one thumb per value.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const value = cell([25, 75]);
@@ -40,7 +40,7 @@ const first = () => value.current[0];
 const second = () => value.current[1];
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <Slider @value={{value.current}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -53,6 +53,7 @@ const second = () => value.current[1];
     <p>Range: {{ (first) }} - {{ (second) }}</p>
 
     <style>
+      @scope {
       .ember-primitives__slider {
         color: #1a73e8;
         width: 300px;
@@ -69,8 +70,9 @@ const second = () => value.current[1];
         font-size: 1.2rem;
         margin-top: 2rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -81,7 +83,7 @@ When you want “ticks”, you typically want the slider to snap to a discrete s
 Pass an array to `@step`.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const tickValues = [0, 10, 20, 30, 40, 50];
@@ -89,7 +91,7 @@ const value = cell(20);
 const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <Slider @value={{value.current}} @step={{tickValues}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -110,6 +112,7 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
     <p>Value: {{value.current}}</p>
 
     <style>
+      @scope {
       .ember-primitives__slider {
         color: #1a73e8;
         width: 300px;
@@ -136,8 +139,9 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
         font-size: 1.2rem;
         margin-top: 0.75rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -148,13 +152,13 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
 (For positioning elements *outside* the thumb, each yielded `thumb` also provides `percent` and a ready-made `positionStyle`.)
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const value = cell([25, 75]);
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <Slider @value={{value.current}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -170,6 +174,7 @@ const value = cell([25, 75]);
     <p>Range: {{value.current}}</p>
 
     <style>
+      @scope {
       .ember-primitives__slider {
         color: #1a73e8;
         width: 300px;
@@ -202,21 +207,22 @@ const value = cell([25, 75]);
         font-size: 1.2rem;
         margin-top: 2rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
 ## Slider With Labels
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const value = cell(50);
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <div class="labels" aria-hidden="true">
       <span>Low</span>
       <span>High</span>
@@ -227,6 +233,7 @@ const value = cell(50);
     <p>Value: {{value.current}}</p>
 
     <style>
+      @scope {
       .labels {
         display: flex;
         width: 300px;
@@ -248,8 +255,9 @@ const value = cell(50);
         font-size: 1.2rem;
         margin-top: 0.75rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -258,7 +266,7 @@ const value = cell(50);
 This pattern keeps an `<input>` in sync with the slider, while letting users type and “commit” on blur / Enter.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { on } from '@ember/modifier';
 import { cell } from 'ember-resources';
 
@@ -295,7 +303,7 @@ const onKeydown = (event) => {
 };
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <div class="row">
       <Slider @value={{value.current}} @onValueChange={{onSliderChange}} @min={{min}} @max={{max}} />
 
@@ -314,6 +322,7 @@ const onKeydown = (event) => {
     </div>
 
     <style>
+      @scope {
       .row {
         display: flex;
         align-items: center;
@@ -343,15 +352,16 @@ const onKeydown = (event) => {
         color: #1a73e8;
         width: 300px;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
 ## Dual Range Slider With Input
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { on } from '@ember/modifier';
 import { cell } from 'ember-resources';
 
@@ -399,7 +409,7 @@ const onKeydown = (commitFn) => (event) => {
 };
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <div class="row">
       <label class="input">
         <span class="sr-only">Minimum</span>
@@ -440,6 +450,7 @@ const onKeydown = (commitFn) => (event) => {
     <p>Range: {{range.current}}</p>
 
     <style>
+      @scope {
       .row {
         display: flex;
         align-items: center;
@@ -480,8 +491,9 @@ const onKeydown = (commitFn) => (event) => {
         font-size: 1.2rem;
         margin-top: 0;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -490,13 +502,13 @@ const onKeydown = (commitFn) => (event) => {
 Any number of values is supported -- each gets a thumb, and thumbs cannot cross each other.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const value = cell([25, 50, 75]);
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <Slider @value={{value.current}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -511,6 +523,7 @@ const value = cell([25, 50, 75]);
     <p>Values: {{value.current}}</p>
 
     <style>
+      @scope {
       .ember-primitives__slider {
         color: #1a73e8;
         width: 300px;
@@ -544,8 +557,9 @@ const value = cell([25, 50, 75]);
         font-size: 1.2rem;
         margin-top: 2rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -554,7 +568,7 @@ const value = cell([25, 50, 75]);
 Vertical orientation is handled by the component (via `writing-mode` on the native inputs) -- set the length with `--ember-primitives__slider__vertical-size`.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 const hz60 = cell(2);
@@ -572,7 +586,7 @@ const bands = [
 ];
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <div class="equalizer" role="group" aria-label="Equalizer">
       {{#each bands as |band|}}
         <div class="band">
@@ -598,6 +612,7 @@ const bands = [
     </div>
 
     <style>
+      @scope {
       .equalizer {
         display: flex;
         justify-content: center;
@@ -648,8 +663,9 @@ const bands = [
         min-width: 2ch;
         text-align: center;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -658,7 +674,7 @@ const bands = [
 This demonstrates composing a “price slider” UI (histogram + dual-range selection + inputs) on top of the primitive.
 
 ```gjs live preview
-import { Slider, Shadowed } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { on } from '@ember/modifier';
 import { cell } from 'ember-resources';
 
@@ -738,7 +754,7 @@ const onKeydown = (commitFn) => (event) => {
 };
 
 <template>
-  <Shadowed>
+  <div class="demo">
     <div class="price">
       <div class="hist" aria-hidden="true">
         {{#each bins as |bin|}}
@@ -793,6 +809,7 @@ const onKeydown = (commitFn) => (event) => {
     </div>
 
     <style>
+      @scope {
       .price {
         width: 420px;
         margin: 2rem auto;
@@ -858,8 +875,9 @@ const onKeydown = (commitFn) => (event) => {
         font-size: 1.1rem;
         margin-top: 1rem;
       }
+      }
     </style>
-  </Shadowed>
+  </div>
 </template>
 ```
 
@@ -915,7 +933,7 @@ Each `<s.Thumb>` renders two elements: an invisible native `<input type="range">
 
 ## Styling
 
-Structural CSS ships with the component. It is attached via [`adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) on the root the slider renders into, so it also works inside shadow roots (the demos on this page are all rendered in shadow DOM). Everything lives in `@layer ember-primitives`, and appearance defaults additionally use `:where()` (zero specificity) and derive from `currentColor` -- any rule you write overrides them, so styling can be as simple as:
+Structural CSS ships with the component. It is attached via [`adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) on the root the slider renders into, so it also works inside shadow roots. Everything lives in `@layer ember-primitives`, and appearance defaults additionally use `:where()` (zero specificity) and derive from `currentColor` -- any rule you write overrides them, so styling can be as simple as:
 
 ```css
 .ember-primitives__slider {
@@ -923,6 +941,8 @@ Structural CSS ships with the component. It is attached via [`adoptedStyleSheets
   width: 300px;
 }
 ```
+
+The demos on this page each scope their appearance CSS with a prelude-less [`@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope) block, which scopes rules to the `<style>` tag's parent element -- style isolation without shadow DOM (and without shadow DOM's focus-navigation quirks).
 
 The visual thumb is centered using the CSS `translate` property, so hover/active effects using `scale` or `transform` compose with it instead of clobbering the positioning:
 

--- a/docs-app/app/templates/3-ui/slider.gjs.md
+++ b/docs-app/app/templates/3-ui/slider.gjs.md
@@ -14,7 +14,7 @@ A custom slider -- as in this component -- is (currently) needed when you want a
 <div class="not-prose">
 
 ```gjs live
-import { Gallery } from '#public/3-ui/slider/gallery';
+import { Gallery } from '#docs/3-ui/slider/gallery';
 
 <template>
   <Gallery />
@@ -23,9 +23,13 @@ import { Gallery } from '#public/3-ui/slider/gallery';
 
 </div>
 
-The CSS technique for moving the sliders involves positioning and rotating an invisible `<input type="range">` over the styled UI -- this maintains `<form>` semantics, and better than accessibility than other techniques.
+Each thumb is an invisible native `<input type="range">` stretched over the styled UI -- this maintains `<form>` semantics and accessibility, without re-implementing keyboard or pointer behavior.
+
+All of the structural CSS needed for this technique (positioning, hiding the native inputs, routing pointer events for multi-thumb sliders, vertical orientation) ships with the component. You only style the appearance: colors, sizes, borders, etc. By default the track, range, and thumb derive their colors from `currentColor`, and every appearance rule has zero specificity -- any selector of yours overrides it.
 
 ## Range Slider
+
+Pass an array to `@value` to get one thumb per value.
 
 ```gjs live preview
 import { Slider, Shadowed } from 'ember-primitives';
@@ -41,112 +45,25 @@ const second = () => value.current[1];
       <s.Track>
         <s.Range />
         {{#each s.thumbs as |thumb|}}
-          <div class="thumb-layer {{if thumb.active 'is-active'}}">
-            <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Value" />
-            <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-          </div>
+          <s.Thumb @thumb={{thumb}} aria-label="Value" />
         {{/each}}
       </s.Track>
     </Slider>
-    
+
     <p>Range: {{ (first) }} - {{ (second) }}</p>
 
     <style>
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 20px;
         margin: 2rem auto;
       }
-      
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-      
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-      
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        z-index: 1;
-      }
 
-      .thumb-layer.is-active {
-        z-index: 3;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        background: transparent;
-        cursor: pointer;
-        appearance: none;
-        /* Multiple full-width range inputs overlap.
-           The active layer is raised via z-index.
-        */
-        pointer-events: none;
-      }
-
-      .thumb-layer input[type="range"]::-webkit-slider-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb-layer input[type="range"]::-moz-range-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 20px;
-        height: 20px;
-        background: #1a73e8;
+      .ember-primitives__slider__thumb {
         border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
 
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer:hover input[type="range"] + .thumb,
-      .thumb-layer input[type="range"]:focus + .thumb,
-      .thumb-layer input[type="range"]:focus-within + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb,
-      .thumb-layer input[type="range"]:active + .thumb {
-        --thumb-scale: 1.45;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-      
       p {
         text-align: center;
         font-size: 1.2rem;
@@ -176,12 +93,8 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
     <Slider @value={{value.current}} @step={{tickValues}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
-
         {{#each s.thumbs as |thumb|}}
-          <div class="thumb-layer">
-            <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Value" />
-            <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-          </div>
+          <s.Thumb @thumb={{thumb}} aria-label="Value" />
         {{/each}}
       </s.Track>
     </Slider>
@@ -198,83 +111,9 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
 
     <style>
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 20px;
         margin: 2rem auto 0.5rem;
-      }
-
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-        pointer-events: none;
-      }
-
-      .thumb-layer input[type="range"]::-webkit-slider-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb-layer input[type="range"]::-moz-range-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
-        border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer input[type="range"]:focus + .thumb,
-      .thumb-layer input[type="range"]:focus-within + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb,
-      .thumb-layer input[type="range"]:active + .thumb {
-        --thumb-scale: 1.45;
       }
 
       .ticks {
@@ -304,7 +143,9 @@ const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
 
 ## Slider With Tooltip (Composed)
 
-The primitive yields `thumb.percent`, which is useful for positioning a tooltip/label.
+`<s.Thumb>` accepts a block, rendered inside the visual thumb -- anything absolutely-positioned in that block moves with the thumb for free.
+
+(For positioning elements *outside* the thumb, each yielded `thumb` also provides `percent` and a ready-made `positionStyle`.)
 
 ```gjs live preview
 import { Slider, Shadowed } from 'ember-primitives';
@@ -319,16 +160,9 @@ const value = cell([25, 75]);
         <s.Range />
 
         {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div class="thumb {{if thumb.active 'is-active'}}" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-          <output class="tooltip" style="left: {{thumb.percent}}%;">
-            {{thumb.value}}
-          </output>
+          <s.Thumb @thumb={{thumb}} aria-label="Value">
+            <output class="tooltip">{{thumb.value}}</output>
+          </s.Thumb>
         {{/each}}
       </s.Track>
     </Slider>
@@ -337,99 +171,21 @@ const value = cell([25, 75]);
 
     <style>
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 32px;
         margin: 2rem auto;
       }
 
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-input {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 32px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-        z-index: 1;
-        pointer-events: none;
-      }
-
-      .thumb-input::-webkit-slider-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb-input::-moz-range-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb-input.is-active {
-        z-index: 10;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
+      .ember-primitives__slider__thumb {
         border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        z-index: 2;
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb.is-active {
-        z-index: 11;
-      }
-
-      .thumb-input:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-
-      .thumb-input:hover + .thumb,
-      .thumb-input:focus + .thumb,
-      .thumb-input:focus-within + .thumb,
-      .thumb-input:focus-visible + .thumb,
-      .thumb-input:active + .thumb {
-        --thumb-scale: 1.45;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
 
       .tooltip {
         position: absolute;
-        top: 50%;
-        transform: translate(-50%, calc(-100% - 16px));
+        bottom: calc(100% + 10px);
+        left: 50%;
+        translate: -50% 0;
         background: #111;
         color: white;
         font-size: 0.75rem;
@@ -438,8 +194,7 @@ const value = cell([25, 75]);
         border-radius: 0.25rem;
         white-space: nowrap;
         user-select: none;
-        pointer-events: none;
-        z-index: 20;
+        font-variant-numeric: tabular-nums;
       }
 
       p {
@@ -467,17 +222,7 @@ const value = cell(50);
       <span>High</span>
     </div>
 
-    <Slider @value={{value.current}} @onValueChange={{value.set}} @step={{10}} as |s|>
-      <s.Track>
-        <s.Range />
-        {{#each s.thumbs as |thumb|}}
-          <div class="thumb-layer">
-            <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Value" />
-            <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-          </div>
-        {{/each}}
-      </s.Track>
-    </Slider>
+    <Slider @value={{value.current}} @onValueChange={{value.set}} @step={{10}} />
 
     <p>Value: {{value.current}}</p>
 
@@ -493,77 +238,9 @@ const value = cell(50);
       }
 
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 20px;
         margin: 0 auto;
-      }
-
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
-        border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer input[type="range"]:focus + .thumb,
-      .thumb-layer input[type="range"]:focus-within + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb,
-      .thumb-layer input[type="range"]:active + .thumb {
-        --thumb-scale: 1.45;
       }
 
       p {
@@ -620,17 +297,7 @@ const onKeydown = (event) => {
 <template>
   <Shadowed>
     <div class="row">
-      <Slider @value={{value.current}} @onValueChange={{onSliderChange}} @min={{min}} @max={{max}} as |s|>
-        <s.Track>
-          <s.Range />
-          {{#each s.thumbs as |thumb|}}
-            <div class="thumb-layer">
-              <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Value" />
-              <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-            </div>
-          {{/each}}
-        </s.Track>
-      </Slider>
+      <Slider @value={{value.current}} @onValueChange={{onSliderChange}} @min={{min}} @max={{max}} />
 
       <label class="input">
         <span class="sr-only">Value</span>
@@ -673,74 +340,8 @@ const onKeydown = (event) => {
       }
 
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 20px;
-        margin: 0;
-      }
-
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
-        border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        --thumb-scale: 1.45;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
       }
     </style>
   </Shadowed>
@@ -817,10 +418,7 @@ const onKeydown = (commitFn) => (event) => {
         <s.Track>
           <s.Range />
           {{#each s.thumbs as |thumb|}}
-            <div class="thumb-layer {{if thumb.active 'is-active'}}">
-              <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Value" />
-              <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-            </div>
+            <s.Thumb @thumb={{thumb}} aria-label="Value" />
           {{/each}}
         </s.Track>
       </Slider>
@@ -868,100 +466,14 @@ const onKeydown = (commitFn) => (event) => {
       }
 
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 20px;
-        margin: 2rem auto;
-      }
-      
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-      
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-      
-      .thumb-layer {
-        position: absolute;
-        pointer-events: none;
-        inset: 0;
-        z-index: 1;
       }
 
-      .thumb-layer.is-active {
-        z-index: 3;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        background: transparent;
-        cursor: pointer;
-        appearance: none;
-        /* Multiple full-width range inputs overlap.
-           The active layer is raised via z-index.
-        */
-        pointer-events: none;
-      }
-
-      .thumb-layer input[type="range"]::-webkit-slider-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb-layer input[type="range"]::-moz-range-thumb {
-        pointer-events: auto;
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 20px;
-        height: 20px;
-        background: #1a73e8;
+      .ember-primitives__slider__thumb {
         border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer:hover input[type="range"] + .thumb,
-      .thumb-layer input[type="range"]:focus + .thumb,
-      .thumb-layer input[type="range"]:focus-within + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb,
-      .thumb-layer input[type="range"]:active + .thumb {
-        --thumb-scale: 1.45;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-      
 
       p {
         text-align: center;
@@ -975,6 +487,8 @@ const onKeydown = (commitFn) => (event) => {
 
 ## Slider With Multiple Thumbs
 
+Any number of values is supported -- each gets a thumb, and thumbs cannot cross each other.
+
 ```gjs live preview
 import { Slider, Shadowed } from 'ember-primitives';
 import { cell } from 'ember-resources';
@@ -987,14 +501,9 @@ const value = cell([25, 50, 75]);
       <s.Track>
         <s.Range />
         {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div class="thumb {{if thumb.active 'is-active'}}" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-          <output class="tooltip" style="left: {{thumb.percent}}%;">{{thumb.value}}%</output>
+          <s.Thumb @thumb={{thumb}} aria-label="Value">
+            <output class="tooltip">{{thumb.value}}%</output>
+          </s.Thumb>
         {{/each}}
       </s.Track>
     </Slider>
@@ -1003,86 +512,22 @@ const value = cell([25, 50, 75]);
 
     <style>
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
+        color: #1a73e8;
         width: 300px;
-        height: 32px;
         margin: 2rem auto;
       }
 
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-input {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 32px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-        z-index: 1;
-        pointer-events: auto;
-      }
-
-      .thumb-input.is-active {
-        z-index: 10;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
+      .ember-primitives__slider__thumb {
         border: 2px solid white;
         border-radius: 6px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        z-index: 2;
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb.is-active {
-        z-index: 11;
-      }
-
-      .thumb-input:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-
-      .thumb-input:hover + .thumb,
-      .thumb-input:focus-visible + .thumb {
-        --thumb-scale: 1.45;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
 
       .tooltip {
         position: absolute;
-        top: 50%;
-        transform: translate(-50%, calc(-100% - 16px));
+        bottom: calc(100% + 10px);
+        left: 50%;
+        translate: -50% 0;
         background: #111;
         color: white;
         font-size: 0.75rem;
@@ -1091,8 +536,7 @@ const value = cell([25, 50, 75]);
         border-radius: 0.25rem;
         white-space: nowrap;
         user-select: none;
-        pointer-events: none;
-        z-index: 20;
+        font-variant-numeric: tabular-nums;
       }
 
       p {
@@ -1106,6 +550,8 @@ const value = cell([25, 50, 75]);
 ```
 
 ## Equalizer
+
+Vertical orientation is handled by the component (via `writing-mode` on the native inputs) -- set the length with `--ember-primitives__slider__vertical-size`.
 
 ```gjs live preview
 import { Slider, Shadowed } from 'ember-primitives';
@@ -1130,26 +576,22 @@ const bands = [
     <div class="equalizer" role="group" aria-label="Equalizer">
       {{#each bands as |band|}}
         <div class="band">
-          <div class="slider-wrap">
-            <Slider
-              @value={{band.value.current}}
-              @onValueChange={{band.value.set}}
-              @min={{-5}}
-              @max={{5}}
-              @orientation="vertical"
-              as |s|>
-              <s.Track>
-                <s.Range />
-                {{#each s.thumbs as |thumb|}}
-                  <div class="thumb-layer">
-                    <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label={{band.label}} />
-                    <div class="thumb" style="bottom: {{thumb.percent}}%;" aria-hidden="true" />
-                  </div>
-                  <output class="tooltip" style="bottom: {{thumb.percent}}%;">{{thumb.value}}</output>
-                {{/each}}
-              </s.Track>
-            </Slider>
-          </div>
+          <Slider
+            @value={{band.value.current}}
+            @onValueChange={{band.value.set}}
+            @min={{-5}}
+            @max={{5}}
+            @orientation="vertical"
+            as |s|>
+            <s.Track>
+              <s.Range />
+              {{#each s.thumbs as |thumb|}}
+                <s.Thumb @thumb={{thumb}} aria-label={{band.label}}>
+                  <output class="tooltip">{{thumb.value}}</output>
+                </s.Thumb>
+              {{/each}}
+            </s.Track>
+          </Slider>
           <div class="band-label" aria-hidden="true">{{band.label}}</div>
         </div>
       {{/each}}
@@ -1177,95 +619,30 @@ const bands = [
         user-select: none;
       }
 
-      .slider-wrap {
-        position: relative;
-        height: 200px;
-        width: 24px;
+      .ember-primitives__slider {
+        color: #1a73e8;
+        --ember-primitives__slider__vertical-size: 200px;
       }
 
-      .ember-primitives__slider[data-orientation="vertical"] {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        width: 24px;
-        height: 200px;
-        margin: 0;
-      }
-
-      .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        width: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__range {
-        position: absolute;
-        width: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        inset: 0;
-        width: 200px;
-        height: 24px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        transform-origin: left top;
-        transform: rotate(-90deg) translateX(-200px);
-        cursor: pointer;
-      }
-
-      .thumb {
-        position: absolute;
-        left: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, 50%) scale(var(--thumb-scale));
+      .ember-primitives__slider__thumb {
         width: 16px;
         height: 20px;
-        background: #1a73e8;
         border: 2px solid white;
         border-radius: 6px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb  {
-        --thumb-scale: 1.45;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
 
       .tooltip {
         position: absolute;
-        left: 50%;
-        transform: translate(-50%, 50%);
+        bottom: 50%;
+        left: calc(100% + 10px);
+        translate: 0 50%;
         background: #111;
         color: white;
         font-size: 0.75rem;
         padding: 0.15rem 0.35rem;
         border-radius: 0.25rem;
         pointer-events: none;
-        z-index: 1;
         white-space: nowrap;
         font-variant-numeric: tabular-nums;
         min-width: 2ch;
@@ -1379,10 +756,7 @@ const onKeydown = (commitFn) => (event) => {
         <s.Track>
           <s.Range />
           {{#each s.thumbs as |thumb|}}
-            <div class="thumb-layer {{if thumb.active 'is-active'}}">
-              <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} aria-label="Price" />
-              <div class="thumb" style="left: {{thumb.percent}}%;" aria-hidden="true" />
-            </div>
+            <s.Thumb @thumb={{thumb}} aria-label="Price" />
           {{/each}}
         </s.Track>
       </Slider>
@@ -1453,81 +827,13 @@ const onKeydown = (commitFn) => (event) => {
       }
 
       .ember-primitives__slider {
-        position: relative;
-        display: flex;
-        align-items: center;
-        width: 100%;
-        height: 20px;
+        color: #1a73e8;
         margin: 1rem 0;
       }
 
-      .ember-primitives__slider__track {
-        position: relative;
-        flex: 1;
-        height: 4px;
-        background: #ddd;
-        border-radius: 2px;
-        overflow: visible;
-      }
-
-      .ember-primitives__slider__range {
-        position: absolute;
-        height: 100%;
-        background: #1a73e8;
-        border-radius: 2px;
-      }
-
-      .thumb-layer {
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-      }
-
-      .thumb-layer.is-active {
-        z-index: 3;
-      }
-
-      .thumb-layer input[type="range"] {
-        position: absolute;
-        left: 0;
-        right: 0;
-        top: 50%;
-        transform: translateY(-50%);
-        width: 100%;
-        height: 20px;
-        margin: 0;
-        opacity: 0;
-        appearance: none;
-        background: transparent;
-        cursor: pointer;
-        pointer-events: auto;
-      }
-
-      .thumb {
-        position: absolute;
-        top: 50%;
-        --thumb-scale: 1;
-        transform-origin: 50% 50%;
-        transform: translate(-50%, -50%) scale(var(--thumb-scale));
-        width: 18px;
-        height: 18px;
-        background: #1a73e8;
+      .ember-primitives__slider__thumb {
         border: 2px solid white;
-        border-radius: 999px;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.2);
-        pointer-events: none;
-        transition: transform 120ms ease;
-      }
-
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        outline: 2px solid #1a73e8;
-        outline-offset: 2px;
-      }
-
-      .thumb-layer input[type="range"]:hover + .thumb,
-      .thumb-layer:hover input[type="range"] + .thumb,
-      .thumb-layer input[type="range"]:focus-visible + .thumb {
-        --thumb-scale: 1.45;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
       }
 
       .inputs {
@@ -1570,7 +876,8 @@ const onKeydown = (commitFn) => (event) => {
 * Horizontal and vertical orientations
 * Customizable min, max, step, and discrete tick values (array `@step`)
 * Disabled state
-* Styleless primitives (you provide CSS)
+* Structural CSS is included -- you only style the appearance (colors, sizes)
+* Default appearance derives from `currentColor` and has zero specificity, so any of your rules override it
 
 ## Anatomy
 
@@ -1587,22 +894,58 @@ import { Slider } from 'ember-primitives/components/slider';
 import { Slider } from 'ember-primitives';
 
 <template>
+  {{! renders the track, range, and thumb(s) for you }}
+  <Slider />
+
+  {{! or compose the pieces yourself }}
   <Slider as |s|>
     <s.Track>
       <s.Range />
       {{#each s.thumbs as |thumb|}}
-        <s.Thumb @value={{thumb.inputValue}} @index={{thumb.index}} />
+        <s.Thumb @thumb={{thumb}} aria-label="Value">
+          {{! optional: rendered inside the visual thumb (tooltips, etc) }}
+        </s.Thumb>
       {{/each}}
     </s.Track>
   </Slider>
 </template>
 ```
 
+Each `<s.Thumb>` renders two elements: an invisible native `<input type="range">` (which receives `...attributes`) and a visual thumb element, positioned along the track for you.
+
+## Styling
+
+Structural CSS ships with the component. It is attached via [`adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) on the root the slider renders into, so it also works inside shadow roots (the demos on this page are all rendered in shadow DOM). Everything lives in `@layer ember-primitives`, and appearance defaults additionally use `:where()` (zero specificity) and derive from `currentColor` -- any rule you write overrides them, so styling can be as simple as:
+
+```css
+.ember-primitives__slider {
+  color: rebeccapurple;
+  width: 300px;
+}
+```
+
+The visual thumb is centered using the CSS `translate` property, so hover/active effects using `scale` or `transform` compose with it instead of clobbering the positioning:
+
+```css
+.ember-primitives__slider__thumb-input:hover + .ember-primitives__slider__thumb {
+  scale: 1.4;
+}
+```
+
+### CSS Custom Properties
+
+| property | description |
+| :---: | :----------- |
+| `--ember-primitives__slider__hit-area` | Size of the pointer target (default `24px`)
+| `--ember-primitives__slider__thumb-size` | Size of the visual thumb (default `16px`)
+| `--ember-primitives__slider__track-thickness` | Thickness of the rail (default `4px`)
+| `--ember-primitives__slider__vertical-size` | Length of a vertical slider (default `10rem`)
+
 ## Accessibility
 
 Each thumb is a native `<input type="range">`, so it gets browser keyboard interaction “for free”.
 
-For accessibility, make sure each thumb has an accessible name. For example, pass `aria-label` / `aria-labelledby` via `...attributes` to `<s.Thumb>`.
+For accessibility, make sure each thumb has an accessible name. For example, pass `aria-label` / `aria-labelledby` via `...attributes` to `<s.Thumb>`. When no block is given to `<Slider>`, default labels are provided (`Value`, or `Minimum` / `Maximum` for a two-thumb range).
 
 ### Keyboard Navigation
 
@@ -1637,6 +980,7 @@ import { ComponentSignature } from 'kolay';
 | :---: | :----------- |
 | `data-orientation` | Set to `"horizontal"` (default) or `"vertical"`
 | `data-disabled` | Present when `@disabled={{true}}`
+| `data-multi` | Present when the slider has more than one thumb
 
 #### `<Track>`
 
@@ -1654,13 +998,17 @@ import { ComponentSignature } from 'kolay';
 
 | key | description |  
 | :---: | :----------- |  
-| `ember-primitives__slider__thumb` | Present on each thumb `<input type="range">`
-| `disabled` | Standard HTML attribute when the thumb is disabled
+| `ember-primitives__slider__thumb-input` | Present on the invisible `<input type="range">` (receives `...attributes`)
+| `ember-primitives__slider__thumb` | Present on the visual thumb element (positioned for you; renders the block)
+| `data-active` | Present on both elements while the thumb is the most-recently-interacted-with
+| `data-disabled` | Present on the visual thumb when the slider is disabled
+| `disabled` | Standard HTML attribute on the input when the slider is disabled
 
 ## References
 
 - W3 - [Slider Multithumb](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/)
 - CSS Tricks - [Multi Thumb Sliders](https://css-tricks.com/multi-thumb-sliders-particular-two-thumb-case/)
 - MDN - [range input](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/range)
+- MDN - [Creating vertical form controls](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_writing_modes/Vertical_controls)
 - utilitybend Proposal - [rangegroup](https://utilitybend.com/blog/a-native-way-of-having-more-than-one-thumb-on-a-range-slider-in-html)
   - open-ui [enhanced range input](https://open-ui.org/components/enhanced-range-input.explainer/)

--- a/docs-app/app/templates/3-ui/slider/basic.gjs
+++ b/docs-app/app/templates/3-ui/slider/basic.gjs
@@ -1,6 +1,3 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
@@ -10,38 +7,11 @@ const value = cell(50);
 
 export const BasicDemo = <template>
   <Shadowed>
-    <Slider @value={{value.current}} @onValueChange={{value.set}} as |s|>
-      <s.Track>
-        <s.Range />
-
-        {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div
-            class="thumb {{if thumb.active 'is-active'}}"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-            aria-hidden="true"
-          />
-        {{/each}}
-      </s.Track>
-    </Slider>
+    {{! Without a block, the Slider renders its track, range, and thumb(s) for you }}
+    <Slider @value={{value.current}} @onValueChange={{value.set}} />
 
     <div class="meta">Value: {{value.current}}</div>
 
     <SliderDemoStyles />
-
-    <style>
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
-      }
-    </style>
   </Shadowed>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/basic.gjs
+++ b/docs-app/app/templates/3-ui/slider/basic.gjs
@@ -1,4 +1,4 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -6,12 +6,12 @@ import { SliderDemoStyles } from './demo-styles.gjs';
 const value = cell(50);
 
 export const BasicDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     {{! Without a block, the Slider renders its track, range, and thumb(s) for you }}
     <Slider @value={{value.current}} @onValueChange={{value.set}} />
 
     <div class="meta">Value: {{value.current}}</div>
 
     <SliderDemoStyles />
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/demo-styles.gjs
+++ b/docs-app/app/templates/3-ui/slider/demo-styles.gjs
@@ -3,124 +3,51 @@ import 'ember-primitives';
 /**
  * Shared, style-only component for Slider demos.
  *
+ * Structural CSS (positioning, invisible native inputs, orientation, etc)
+ * ships with the <Slider> component itself — everything here is
+ * appearance-only: colors, sizes, tooltips.
+ *
  * Each demo is wrapped in <Shadowed>, so these styles won't leak.
  */
 export const SliderDemoStyles = <template>
   <span hidden aria-hidden="true"></span>
   <style>
     .ember-primitives__slider {
-      --slider-width: 100%;
-      --slider-hit-area: 32px;
-      --thumb-size: 18px;
-      --slider-v-height: 140px;
-      --slider-v-width: 24px;
+      /* the track/range/thumb all derive from currentColor by default */
+      color: #1a73e8;
+      width: 100%;
+      --ember-primitives__slider__thumb-size: 18px;
+    }
 
-      position: relative;
-      display: flex;
-      align-items: center;
-      width: var(--slider-width);
-      height: var(--slider-hit-area);
+    .ember-primitives__slider[data-orientation="vertical"] {
+      width: auto;
+      --ember-primitives__slider__vertical-size: 140px;
     }
 
     .ember-primitives__slider__track {
-      position: relative;
-      flex: 1;
-      height: 4px;
       background: #ddd;
-      border-radius: 2px;
-      overflow: visible;
     }
 
-    .ember-primitives__slider__range {
-      position: absolute;
-      height: 100%;
-      background: #1a73e8;
-      border-radius: 2px;
-    }
-
-    .thumb-input {
-      position: absolute;
-      left: 0;
-      right: 0;
-      top: 50%;
-      transform: translateY(-50%);
-      width: 100%;
-      height: var(--slider-hit-area);
-      margin: 0;
-      opacity: 0;
-      appearance: none;
-      background: transparent;
-      cursor: pointer;
-      z-index: 1;
-
-      /*
-        Multi-thumb sliders overlap multiple full-width range inputs.
-        If the inputs receive pointer events, the top-most input steals
-        clicks/drags from other thumbs.
-
-        Disable pointer events on the track-sized input area and re-enable
-        them on the thumb pseudo-element.
-      */
-      pointer-events: none;
-    }
-
-    .thumb-input::-webkit-slider-thumb {
-      pointer-events: auto;
-      cursor: pointer;
-    }
-
-    .thumb-input::-moz-range-thumb {
-      pointer-events: auto;
-      cursor: pointer;
-    }
-
-    .thumb-input.is-active {
-      z-index: 10;
-    }
-
-    .thumb-input:disabled {
-      cursor: not-allowed;
-    }
-
-    .thumb {
-      position: absolute;
-      top: 50%;
-      --thumb-scale: 1;
-      transform-origin: 50% 50%;
-      transform: translate(-50%, -50%) scale(var(--thumb-scale));
-      width: var(--thumb-size);
-      height: var(--thumb-size);
-      background: #1a73e8;
+    .ember-primitives__slider__thumb {
       border: 2px solid white;
-      border-radius: 999px;
       box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-      z-index: 2;
-      pointer-events: none;
-      transition: transform 120ms ease;
+      transition: box-shadow 120ms ease;
     }
 
-    .thumb-input:not(:disabled):hover + .thumb,
-    .thumb-input:not(:disabled):focus-visible + .thumb {
-      --thumb-scale: 1.45;
+    .ember-primitives__slider__thumb-input:not(:disabled):hover + .ember-primitives__slider__thumb,
+    .ember-primitives__slider__thumb-input:not(:disabled):focus-visible
+      + .ember-primitives__slider__thumb {
+      box-shadow:
+        0 2px 4px rgba(0, 0, 0, 0.2),
+        0 0 0 5px color-mix(in srgb, currentColor 25%, transparent);
     }
 
-    .thumb.is-active {
-      z-index: 11;
-    }
-
-    .thumb.is-disabled {
-      opacity: 0.5;
-    }
-
-    .thumb-input:focus-visible + .thumb {
-      outline: 2px solid #1a73e8;
-      outline-offset: 2px;
-    }
-
+    /* Tooltips are rendered inside the thumb, via <s.Thumb>'s block */
     .tooltip {
       position: absolute;
-      top: 50%;
-      transform: translate(-50%, calc(-100% - 16px));
+      bottom: calc(100% + 10px);
+      left: 50%;
+      translate: -50% 0;
       background: #111;
       color: white;
       font-size: 0.75rem;
@@ -129,51 +56,23 @@ export const SliderDemoStyles = <template>
       border-radius: 0.25rem;
       white-space: nowrap;
       user-select: none;
-      pointer-events: none;
-      z-index: 20;
       font-variant-numeric: tabular-nums;
       min-width: 2ch;
       text-align: center;
     }
 
-    .ember-primitives__slider[data-orientation="vertical"] {
-      flex-direction: column;
-      width: var(--slider-v-width);
-      height: var(--slider-v-height);
-      margin: 0.5rem 0;
+    .tooltip--vertical {
+      bottom: 50%;
+      left: calc(100% + 10px);
+      translate: 0 50%;
     }
 
-    .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__track {
-      width: 4px;
-      height: 100%;
-    }
-
-    .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__range {
-      width: 100%;
-      height: auto;
-    }
-
-    .ember-primitives__slider[data-orientation="vertical"] .thumb-input {
-      left: 0;
-      top: 0;
-      right: auto;
-      bottom: auto;
-      width: var(--slider-v-height);
-      height: var(--slider-v-width);
-      transform: rotate(-90deg) translateX(calc(-1 * var(--slider-v-height))) translateY(-50%);
-      transform-origin: left top;
-    }
-
-    .ember-primitives__slider[data-orientation="vertical"] .thumb {
-      left: 50%;
-      top: auto;
-      transform: translate(-50%, 50%) scale(var(--thumb-scale));
-    }
-
-    .tooltip.tooltip--vertical {
-      left: 50%;
-      top: auto;
-      transform: translate(14px, 50%);
+    .meta {
+      margin-top: 0.75rem;
+      font-variant-numeric: tabular-nums;
+      color: #333;
+      font-size: 0.9rem;
+      text-align: center;
     }
   </style>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/demo-styles.gjs
+++ b/docs-app/app/templates/3-ui/slider/demo-styles.gjs
@@ -7,72 +7,77 @@ import 'ember-primitives';
  * ships with the <Slider> component itself — everything here is
  * appearance-only: colors, sizes, tooltips.
  *
- * Each demo is wrapped in <Shadowed>, so these styles won't leak.
+ * The prelude-less `@scope` block scopes these rules to the style tag's
+ * parent element, so each demo's styles stay contained to that demo —
+ * no shadow DOM needed. (Shadow DOM previously broke sequential focus
+ * navigation in Chrome when demos follow code snippets.)
  */
 export const SliderDemoStyles = <template>
-  <span hidden aria-hidden="true"></span>
   <style>
-    .ember-primitives__slider {
-      /* the track/range/thumb all derive from currentColor by default */
-      color: #1a73e8;
-      width: 100%;
-      --ember-primitives__slider__thumb-size: 18px;
-    }
+    @scope {
+      .ember-primitives__slider {
+        /* the track/range/thumb all derive from currentColor by default */
+        color: #1a73e8;
+        width: 100%;
+        --ember-primitives__slider__thumb-size: 18px;
+      }
 
-    .ember-primitives__slider[data-orientation="vertical"] {
-      width: auto;
-      --ember-primitives__slider__vertical-size: 140px;
-    }
+      .ember-primitives__slider[data-orientation="vertical"] {
+        width: auto;
+        --ember-primitives__slider__vertical-size: 140px;
+      }
 
-    .ember-primitives__slider__track {
-      background: #ddd;
-    }
+      .ember-primitives__slider__track {
+        background: #ddd;
+      }
 
-    .ember-primitives__slider__thumb {
-      border: 2px solid white;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-      transition: box-shadow 120ms ease;
-    }
+      .ember-primitives__slider__thumb {
+        border: 2px solid white;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+        transition: box-shadow 120ms ease;
+      }
 
-    .ember-primitives__slider__thumb-input:not(:disabled):hover + .ember-primitives__slider__thumb,
-    .ember-primitives__slider__thumb-input:not(:disabled):focus-visible
-      + .ember-primitives__slider__thumb {
-      box-shadow:
-        0 2px 4px rgba(0, 0, 0, 0.2),
-        0 0 0 5px color-mix(in srgb, currentColor 25%, transparent);
-    }
+      .ember-primitives__slider__thumb-input:not(:disabled):hover
+        + .ember-primitives__slider__thumb,
+      .ember-primitives__slider__thumb-input:not(:disabled):focus-visible
+        + .ember-primitives__slider__thumb {
+        box-shadow:
+          0 2px 4px rgba(0, 0, 0, 0.2),
+          0 0 0 5px color-mix(in srgb, currentColor 25%, transparent);
+      }
 
-    /* Tooltips are rendered inside the thumb, via <s.Thumb>'s block */
-    .tooltip {
-      position: absolute;
-      bottom: calc(100% + 10px);
-      left: 50%;
-      translate: -50% 0;
-      background: #111;
-      color: white;
-      font-size: 0.75rem;
-      line-height: 1;
-      padding: 0.15rem 0.35rem;
-      border-radius: 0.25rem;
-      white-space: nowrap;
-      user-select: none;
-      font-variant-numeric: tabular-nums;
-      min-width: 2ch;
-      text-align: center;
-    }
+      /* Tooltips are rendered inside the thumb, via <s.Thumb>'s block */
+      .tooltip {
+        position: absolute;
+        bottom: calc(100% + 10px);
+        left: 50%;
+        translate: -50% 0;
+        background: #111;
+        color: white;
+        font-size: 0.75rem;
+        line-height: 1;
+        padding: 0.15rem 0.35rem;
+        border-radius: 0.25rem;
+        white-space: nowrap;
+        user-select: none;
+        font-variant-numeric: tabular-nums;
+        min-width: 2ch;
+        text-align: center;
+      }
 
-    .tooltip--vertical {
-      bottom: 50%;
-      left: calc(100% + 10px);
-      translate: 0 50%;
-    }
+      .tooltip--vertical {
+        bottom: 50%;
+        left: calc(100% + 10px);
+        translate: 0 50%;
+      }
 
-    .meta {
-      margin-top: 0.75rem;
-      font-variant-numeric: tabular-nums;
-      color: #333;
-      font-size: 0.9rem;
-      text-align: center;
+      .meta {
+        margin-top: 0.75rem;
+        font-variant-numeric: tabular-nums;
+        color: #333;
+        font-size: 0.9rem;
+        text-align: center;
+      }
     }
   </style>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/disabled.gjs
+++ b/docs-app/app/templates/3-ui/slider/disabled.gjs
@@ -1,13 +1,13 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
 
 export const DisabledDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <Slider @value={{60}} @disabled={{true}} />
 
     <div class="meta">Value: 60</div>
 
     <SliderDemoStyles />
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/disabled.gjs
+++ b/docs-app/app/templates/3-ui/slider/disabled.gjs
@@ -1,44 +1,13 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
 
 export const DisabledDemo = <template>
   <Shadowed>
-    <Slider @value={{60}} @disabled={{true}} as |s|>
-      <s.Track>
-        <s.Range />
-
-        {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input"
-            aria-label="Value"
-          />
-          <div
-            class="thumb is-disabled"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-            aria-hidden="true"
-          />
-        {{/each}}
-      </s.Track>
-    </Slider>
+    <Slider @value={{60}} @disabled={{true}} />
 
     <div class="meta">Value: 60</div>
 
     <SliderDemoStyles />
-
-    <style>
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
-      }
-    </style>
   </Shadowed>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/equalizer.gjs
+++ b/docs-app/app/templates/3-ui/slider/equalizer.gjs
@@ -1,6 +1,4 @@
-import { concat } from '@ember/helper';
 import { on } from '@ember/modifier';
-import { htmlSafe } from '@ember/template';
 
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
@@ -33,7 +31,7 @@ export const EqualizerDemo = <template>
       {{#each bands as |band|}}
         <div class="eq-band">
           <Slider
-            style="--slider-v-height: 120px;"
+            style="--ember-primitives__slider__vertical-size: 120px;"
             @value={{band.value.current}}
             @onValueChange={{band.value.set}}
             @min={{-5}}
@@ -46,9 +44,7 @@ export const EqualizerDemo = <template>
 
               {{#each s.thumbs as |thumb|}}
                 <s.Thumb
-                  @value={{thumb.inputValue}}
-                  @index={{thumb.index}}
-                  class="thumb-input {{if thumb.active 'is-active'}}"
+                  @thumb={{thumb}}
                   aria-label={{band.label}}
                   {{on "pointerup" (startDrag band.label)}}
                   {{on "gotpointercapture" (startDrag band.label)}}
@@ -58,20 +54,11 @@ export const EqualizerDemo = <template>
                   {{on "lostpointercapture" endDrag}}
                   {{on "change" endDrag}}
                   {{on "blur" endDrag}}
-                />
-                <div
-                  class="thumb {{if thumb.active 'is-active'}}"
-                  style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-                  aria-hidden="true"
-                />
-                {{#if (isDragging band.label)}}
-                  <output
-                    class="tooltip tooltip--vertical"
-                    style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-                  >
-                    {{thumb.value}}
-                  </output>
-                {{/if}}
+                >
+                  {{#if (isDragging band.label)}}
+                    <output class="tooltip tooltip--vertical">{{thumb.value}}</output>
+                  {{/if}}
+                </s.Thumb>
               {{/each}}
             </s.Track>
           </Slider>

--- a/docs-app/app/templates/3-ui/slider/equalizer.gjs
+++ b/docs-app/app/templates/3-ui/slider/equalizer.gjs
@@ -1,6 +1,6 @@
 import { on } from '@ember/modifier';
 
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -26,7 +26,7 @@ const endDrag = () => draggingLabel.set(null);
 const isDragging = (label) => draggingLabel.current === label;
 
 export const EqualizerDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <div class="eq-mini" role="group" aria-label="Equalizer">
       {{#each bands as |band|}}
         <div class="eq-band">
@@ -71,24 +71,26 @@ export const EqualizerDemo = <template>
     <SliderDemoStyles />
 
     <style>
-      .eq-mini {
-        display: flex;
-        justify-content: center;
-        gap: 0.75rem;
-        padding: 0.25rem 0;
-      }
+      @scope {
+        .eq-mini {
+          display: flex;
+          justify-content: center;
+          gap: 0.75rem;
+          padding: 0.25rem 0;
+        }
 
-      .eq-band {
-        display: grid;
-        justify-items: center;
-        gap: 0.25rem;
-      }
+        .eq-band {
+          display: grid;
+          justify-items: center;
+          gap: 0.25rem;
+        }
 
-      .eq-label {
-        font-size: 0.7rem;
-        color: #333;
-        user-select: none;
+        .eq-label {
+          font-size: 0.7rem;
+          color: #333;
+          user-select: none;
+        }
       }
     </style>
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/histogram-range.gjs
+++ b/docs-app/app/templates/3-ui/slider/histogram-range.gjs
@@ -69,17 +69,7 @@ export const HistogramRangeDemo = <template>
           <s.Range />
 
           {{#each s.thumbs as |thumb|}}
-            <s.Thumb
-              @value={{thumb.inputValue}}
-              @index={{thumb.index}}
-              class="thumb-input {{if thumb.active 'is-active'}}"
-              aria-label="Price"
-            />
-            <div
-              class="thumb {{if thumb.active 'is-active'}}"
-              style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-              aria-hidden="true"
-            />
+            <s.Thumb @thumb={{thumb}} aria-label="Price" />
           {{/each}}
         </s.Track>
       </Slider>
@@ -120,14 +110,6 @@ export const HistogramRangeDemo = <template>
 
       .hist-mini .bar.active {
         background: #1a73e8;
-      }
-
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
       }
     </style>
   </Shadowed>

--- a/docs-app/app/templates/3-ui/slider/histogram-range.gjs
+++ b/docs-app/app/templates/3-ui/slider/histogram-range.gjs
@@ -1,7 +1,7 @@
 import { concat } from '@ember/helper';
 import { htmlSafe } from '@ember/template';
 
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -43,7 +43,7 @@ const isInRange = (bin) => {
 };
 
 export const HistogramRangeDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <div class="price-mini">
       <div class="hist-mini" aria-hidden="true">
         {{#each bins as |bin|}}
@@ -80,37 +80,39 @@ export const HistogramRangeDemo = <template>
     <SliderDemoStyles />
 
     <style>
-      .price-mini {
-        width: 100%;
-      }
+      @scope {
+        .price-mini {
+          width: 100%;
+        }
 
-      .hist-mini {
-        display: flex;
-        gap: 2px;
-        height: 56px;
-        align-items: flex-end;
-        background: #fafafa;
-        border-radius: 6px;
-        padding: 6px;
-        margin-bottom: 0.5rem;
-      }
+        .hist-mini {
+          display: flex;
+          gap: 2px;
+          height: 56px;
+          align-items: flex-end;
+          background: #fafafa;
+          border-radius: 6px;
+          padding: 6px;
+          margin-bottom: 0.5rem;
+        }
 
-      .hist-mini .bar-wrap {
-        flex: 1;
-        height: 100%;
-        display: flex;
-        align-items: flex-end;
-      }
+        .hist-mini .bar-wrap {
+          flex: 1;
+          height: 100%;
+          display: flex;
+          align-items: flex-end;
+        }
 
-      .hist-mini .bar {
-        width: 100%;
-        background: #cfd8e3;
-        border-radius: 4px 4px 0 0;
-      }
+        .hist-mini .bar {
+          width: 100%;
+          background: #cfd8e3;
+          border-radius: 4px 4px 0 0;
+        }
 
-      .hist-mini .bar.active {
-        background: #1a73e8;
+        .hist-mini .bar.active {
+          background: #1a73e8;
+        }
       }
     </style>
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/multi.gjs
+++ b/docs-app/app/templates/3-ui/slider/multi.gjs
@@ -1,4 +1,4 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -6,7 +6,7 @@ import { SliderDemoStyles } from './demo-styles.gjs';
 const values = cell([25, 50, 75]);
 
 export const MultiThumbDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <Slider @value={{values.current}} @onValueChange={{values.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -22,5 +22,5 @@ export const MultiThumbDemo = <template>
     <div class="meta">Values: {{values.current}}</div>
 
     <SliderDemoStyles />
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/multi.gjs
+++ b/docs-app/app/templates/3-ui/slider/multi.gjs
@@ -1,6 +1,3 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
@@ -15,21 +12,9 @@ export const MultiThumbDemo = <template>
         <s.Range />
 
         {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div
-            class="thumb {{if thumb.active 'is-active'}}"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-            aria-hidden="true"
-          />
-          <output
-            class="tooltip"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-          >{{thumb.value}}%</output>
+          <s.Thumb @thumb={{thumb}} aria-label="Value">
+            <output class="tooltip">{{thumb.value}}%</output>
+          </s.Thumb>
         {{/each}}
       </s.Track>
     </Slider>
@@ -37,15 +22,5 @@ export const MultiThumbDemo = <template>
     <div class="meta">Values: {{values.current}}</div>
 
     <SliderDemoStyles />
-
-    <style>
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
-      }
-    </style>
   </Shadowed>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/range.gjs
+++ b/docs-app/app/templates/3-ui/slider/range.gjs
@@ -1,6 +1,3 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
@@ -15,21 +12,9 @@ export const RangeDemo = <template>
         <s.Range />
 
         {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div
-            class="thumb {{if thumb.active 'is-active'}}"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-            aria-hidden="true"
-          />
-          <output
-            class="tooltip"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-          >{{thumb.value}}</output>
+          <s.Thumb @thumb={{thumb}} aria-label="Value">
+            <output class="tooltip">{{thumb.value}}</output>
+          </s.Thumb>
         {{/each}}
       </s.Track>
     </Slider>
@@ -37,15 +22,5 @@ export const RangeDemo = <template>
     <div class="meta">Range: {{range.current}}</div>
 
     <SliderDemoStyles />
-
-    <style>
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
-      }
-    </style>
   </Shadowed>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/range.gjs
+++ b/docs-app/app/templates/3-ui/slider/range.gjs
@@ -1,4 +1,4 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -6,7 +6,7 @@ import { SliderDemoStyles } from './demo-styles.gjs';
 const range = cell([25, 75]);
 
 export const RangeDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <Slider @value={{range.current}} @onValueChange={{range.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -22,5 +22,5 @@ export const RangeDemo = <template>
     <div class="meta">Range: {{range.current}}</div>
 
     <SliderDemoStyles />
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/ticks.gjs
+++ b/docs-app/app/templates/3-ui/slider/ticks.gjs
@@ -1,7 +1,7 @@
 import { concat } from '@ember/helper';
 import { htmlSafe } from '@ember/template';
 
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -11,7 +11,7 @@ const value = cell(20);
 const percentAt = (index) => (index / (tickValues.length - 1)) * 100;
 
 export const TicksDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <Slider @value={{value.current}} @step={{tickValues}} @onValueChange={{value.set}} as |s|>
       <s.Track>
         <s.Range />
@@ -33,19 +33,21 @@ export const TicksDemo = <template>
     <SliderDemoStyles />
 
     <style>
-      .ticks {
-        position: relative;
-        margin-top: 0.25rem;
-        height: 18px;
-      }
+      @scope {
+        .ticks {
+          position: relative;
+          margin-top: 0.25rem;
+          height: 18px;
+        }
 
-      .tick {
-        position: absolute;
-        transform: translateX(-50%);
-        font-size: 0.75rem;
-        color: #444;
-        user-select: none;
+        .tick {
+          position: absolute;
+          transform: translateX(-50%);
+          font-size: 0.75rem;
+          color: #444;
+          user-select: none;
+        }
       }
     </style>
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/ticks.gjs
+++ b/docs-app/app/templates/3-ui/slider/ticks.gjs
@@ -17,17 +17,7 @@ export const TicksDemo = <template>
         <s.Range />
 
         {{#each s.thumbs as |thumb|}}
-          <s.Thumb
-            @value={{thumb.inputValue}}
-            @index={{thumb.index}}
-            class="thumb-input {{if thumb.active 'is-active'}}"
-            aria-label="Value"
-          />
-          <div
-            class="thumb {{if thumb.active 'is-active'}}"
-            style={{htmlSafe (concat "left: " thumb.percent "%;")}}
-            aria-hidden="true"
-          />
+          <s.Thumb @thumb={{thumb}} aria-label="Value" />
         {{/each}}
       </s.Track>
     </Slider>
@@ -55,14 +45,6 @@ export const TicksDemo = <template>
         font-size: 0.75rem;
         color: #444;
         user-select: none;
-      }
-
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
       }
     </style>
   </Shadowed>

--- a/docs-app/app/templates/3-ui/slider/vertical-range.gjs
+++ b/docs-app/app/templates/3-ui/slider/vertical-range.gjs
@@ -1,4 +1,4 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -6,7 +6,7 @@ import { SliderDemoStyles } from './demo-styles.gjs';
 const range = cell([30, 70]);
 
 export const VerticalRangeDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <div class="v-row">
       <Slider @value={{range.current}} @onValueChange={{range.set}} @orientation="vertical" as |s|>
         <s.Track>
@@ -26,12 +26,14 @@ export const VerticalRangeDemo = <template>
     <SliderDemoStyles />
 
     <style>
-      .v-row {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 170px;
+      @scope {
+        .v-row {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 170px;
+        }
       }
     </style>
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/vertical-range.gjs
+++ b/docs-app/app/templates/3-ui/slider/vertical-range.gjs
@@ -1,6 +1,3 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
@@ -16,23 +13,9 @@ export const VerticalRangeDemo = <template>
           <s.Range />
 
           {{#each s.thumbs as |thumb|}}
-            <s.Thumb
-              @value={{thumb.inputValue}}
-              @index={{thumb.index}}
-              class="thumb-input {{if thumb.active 'is-active'}}"
-              aria-label="Value"
-            />
-            <div
-              class="thumb {{if thumb.active 'is-active'}}"
-              style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-              aria-hidden="true"
-            />
-            <output
-              class="tooltip tooltip--vertical"
-              style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-            >
-              {{thumb.value}}
-            </output>
+            <s.Thumb @thumb={{thumb}} aria-label="Value">
+              <output class="tooltip tooltip--vertical">{{thumb.value}}</output>
+            </s.Thumb>
           {{/each}}
         </s.Track>
       </Slider>
@@ -48,14 +31,6 @@ export const VerticalRangeDemo = <template>
         align-items: center;
         justify-content: center;
         min-height: 170px;
-      }
-
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
       }
     </style>
   </Shadowed>

--- a/docs-app/app/templates/3-ui/slider/vertical.gjs
+++ b/docs-app/app/templates/3-ui/slider/vertical.gjs
@@ -1,4 +1,4 @@
-import { Shadowed, Slider } from 'ember-primitives';
+import { Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
 import { SliderDemoStyles } from './demo-styles.gjs';
@@ -6,7 +6,7 @@ import { SliderDemoStyles } from './demo-styles.gjs';
 const value = cell(40);
 
 export const VerticalDemo = <template>
-  <Shadowed>
+  <div class="slider-demo">
     <div class="v-row">
       <Slider @value={{value.current}} @onValueChange={{value.set}} @orientation="vertical" as |s|>
         <s.Track>
@@ -26,12 +26,14 @@ export const VerticalDemo = <template>
     <SliderDemoStyles />
 
     <style>
-      .v-row {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        min-height: 170px;
+      @scope {
+        .v-row {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          min-height: 170px;
+        }
       }
     </style>
-  </Shadowed>
+  </div>
 </template>;

--- a/docs-app/app/templates/3-ui/slider/vertical.gjs
+++ b/docs-app/app/templates/3-ui/slider/vertical.gjs
@@ -1,6 +1,3 @@
-import { concat } from '@ember/helper';
-import { htmlSafe } from '@ember/template';
-
 import { Shadowed, Slider } from 'ember-primitives';
 import { cell } from 'ember-resources';
 
@@ -16,23 +13,9 @@ export const VerticalDemo = <template>
           <s.Range />
 
           {{#each s.thumbs as |thumb|}}
-            <s.Thumb
-              @value={{thumb.inputValue}}
-              @index={{thumb.index}}
-              class="thumb-input {{if thumb.active 'is-active'}}"
-              aria-label="Value"
-            />
-            <div
-              class="thumb {{if thumb.active 'is-active'}}"
-              style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-              aria-hidden="true"
-            />
-            <output
-              class="tooltip tooltip--vertical"
-              style={{htmlSafe (concat "bottom: " thumb.percent "%;")}}
-            >
-              {{thumb.value}}
-            </output>
+            <s.Thumb @thumb={{thumb}} aria-label="Value">
+              <output class="tooltip tooltip--vertical">{{thumb.value}}</output>
+            </s.Thumb>
           {{/each}}
         </s.Track>
       </Slider>
@@ -48,14 +31,6 @@ export const VerticalDemo = <template>
         align-items: center;
         justify-content: center;
         min-height: 170px;
-      }
-
-      .meta {
-        margin-top: 0.75rem;
-        font-variant-numeric: tabular-nums;
-        color: #333;
-        font-size: 0.9rem;
-        text-align: center;
       }
     </style>
   </Shadowed>

--- a/docs-app/index.html
+++ b/docs-app/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <title>ember-primitives</title>

--- a/ember-primitives/src/components/slider.gts
+++ b/ember-primitives/src/components/slider.gts
@@ -2,7 +2,8 @@ import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 
-import { SliderStore, type SliderThumb } from "./slider/store.ts";
+import { SliderStore, type SliderThumb, type StyleString } from "./slider/store.ts";
+import { adoptStyles } from "./slider/style.ts";
 
 import type { TOC } from "@ember/component/template-only";
 import type Owner from "@ember/owner";
@@ -119,7 +120,7 @@ const Track: TOC<TrackSignature> = <template>
 interface RangeSignature {
   Element: HTMLSpanElement;
   Args: {
-    rangeStyle: string;
+    rangeStyle: StyleString;
   };
 }
 
@@ -128,6 +129,10 @@ const Range: TOC<RangeSignature> = <template>
 </template>;
 
 class ThumbComponent extends Component<{
+  /**
+   * `...attributes` land on the invisible native input, which is the
+   * interactive element (pass `aria-label` / `aria-labelledby` here).
+   */
   Element: HTMLInputElement;
   Args: {
     store: SliderStore;
@@ -138,6 +143,12 @@ class ThumbComponent extends Component<{
     value?: number;
     index?: number;
   };
+  Blocks: {
+    /**
+     * Rendered inside the visual thumb — useful for tooltips / value labels.
+     */
+    default: [];
+  };
 }> {
   get index(): number {
     return this.args.thumb?.index ?? this.args.index ?? 0;
@@ -146,6 +157,16 @@ class ThumbComponent extends Component<{
   get value(): number {
     // When using tick values, the `input` needs the internal index.
     return this.args.thumb?.inputValue ?? this.args.value ?? this.args.store.internalMin;
+  }
+
+  get isActive(): boolean {
+    return this.args.store.activeThumbIndex === this.index;
+  }
+
+  get positionStyle() {
+    const percent = this.args.thumb?.percent ?? this.args.store.thumbPercents[this.index] ?? 0;
+
+    return this.args.store.thumbPositionStyle(percent);
   }
 
   private readValue(event: Event): number {
@@ -184,19 +205,27 @@ class ThumbComponent extends Component<{
   <template>
     <input
       ...attributes
-      class="ember-primitives__slider__thumb"
+      class="ember-primitives__slider__thumb-input"
       type="range"
       min={{@store.internalMin}}
       max={{@store.internalMax}}
       step={{@store.internalStep}}
       value={{this.value}}
       disabled={{@store.disabled}}
+      data-active={{if this.isActive ""}}
       {{on "gotpointercapture" this.onGotPointerCapture}}
       {{on "pointerup" this.onPointerUp}}
       {{on "focus" this.onFocus}}
       {{on "input" this.onInput}}
       {{on "change" this.onChange}}
     />
+    <span
+      class="ember-primitives__slider__thumb"
+      style={{this.positionStyle}}
+      data-active={{if this.isActive ""}}
+      data-disabled={{if @store.disabled ""}}
+      aria-hidden="true"
+    >{{yield}}</span>
   </template>
 }
 
@@ -215,6 +244,8 @@ export class Slider extends Component<Signature> {
       class="ember-primitives__slider"
       data-orientation={{this.store.orientation}}
       data-disabled={{if this.store.disabled ""}}
+      data-multi={{if this.store.isMulti ""}}
+      {{adoptStyles}}
     >
       {{#if (has-block)}}
         {{yield

--- a/ember-primitives/src/components/slider/store.ts
+++ b/ember-primitives/src/components/slider/store.ts
@@ -1,4 +1,11 @@
 import { tracked } from '@glimmer/tracking';
+import { htmlSafe } from '@ember/template';
+
+/**
+ * `style` attribute values need to be SafeStrings to avoid Ember's
+ * style-binding warning.
+ */
+export type StyleString = ReturnType<typeof htmlSafe>;
 
 export interface SliderStoreArgs {
   value?: number | number[];
@@ -23,6 +30,11 @@ export interface SliderThumb {
   inputValue: number;
   percent: number;
   active: boolean;
+  /**
+   * Inline style positioning this thumb along the track
+   * (`left: x%` or `bottom: x%`, depending on orientation).
+   */
+  positionStyle: StyleString;
 }
 
 const DEFAULT_MIN = 0;
@@ -111,6 +123,10 @@ class ThumbState implements SliderThumb {
 
   get active(): boolean {
     return this.#slider.activeThumbIndex === this.index;
+  }
+
+  get positionStyle(): StyleString {
+    return this.#slider.thumbPositionStyle(this.percent);
   }
 }
 
@@ -238,7 +254,17 @@ export class SliderStore {
     );
   }
 
-  get rangeStyle(): string {
+  get isMulti(): boolean {
+    return this.internalValues.length > 1;
+  }
+
+  thumbPositionStyle = (percent: number): StyleString => {
+    const property = this.orientation === 'horizontal' ? 'left' : 'bottom';
+
+    return htmlSafe(`${property}: ${percent}%`);
+  };
+
+  get rangeStyle(): StyleString {
     const internalValues = this.internalValues;
 
     // For a single-thumb slider, the "range" should fill from the start to the
@@ -251,9 +277,9 @@ export class SliderStore {
     const endPercent = getPercentage(internalRangeMax, this.internalMin, this.internalMax);
 
     if (this.orientation === 'horizontal') {
-      return `left: ${startPercent}%; right: ${100 - endPercent}%`;
+      return htmlSafe(`left: ${startPercent}%; right: ${100 - endPercent}%`);
     } else {
-      return `bottom: ${startPercent}%; top: ${100 - endPercent}%`;
+      return htmlSafe(`bottom: ${startPercent}%; top: ${100 - endPercent}%`);
     }
   }
 

--- a/ember-primitives/src/components/slider/style.ts
+++ b/ember-primitives/src/components/slider/style.ts
@@ -1,0 +1,240 @@
+import { modifier } from 'ember-modifier';
+
+/**
+ * Structural styles for <Slider>.
+ *
+ * These handle the annoying parts of building a custom slider on top of
+ * native <input type="range"> elements:
+ *   - stretching an invisible native input over the track (so keyboard,
+ *     pointer, and assistive-tech behavior all come from the platform)
+ *   - letting multiple overlapping inputs coexist (multi-thumb / range
+ *     sliders) by routing pointer events through the native thumb only
+ *   - vertical orientation (via `writing-mode`, no rotation hacks)
+ *   - positioning the visual thumb and keeping the active thumb on top
+ *
+ * Appearance (colors, exact sizes) is left to the consumer.
+ *
+ * Everything is wrapped in `@layer ember-primitives`, so *any* unlayered
+ * consumer rule overrides these -- regardless of specificity or order.
+ *
+ * These styles are attached via `document.adoptedStyleSheets` (or the
+ * containing ShadowRoot's) rather than a css file, so the component works
+ * inside shadow roots, where document-level stylesheets don't reach.
+ *
+ * Knobs:
+ *   --ember-primitives__slider__hit-area         pointer target size (default 24px)
+ *   --ember-primitives__slider__thumb-size       visual thumb size (default 16px)
+ *   --ember-primitives__slider__track-thickness  rail thickness (default 4px)
+ *   --ember-primitives__slider__vertical-size    length of a vertical slider (default 10rem)
+ */
+const styles = /* css */ `
+@layer ember-primitives {
+  .ember-primitives__slider {
+    position: relative;
+    display: flex;
+    align-items: center;
+    min-height: var(--ember-primitives__slider__hit-area, 24px);
+  }
+
+  .ember-primitives__slider[data-orientation="vertical"] {
+    flex-direction: column;
+    min-height: 0;
+    min-width: var(--ember-primitives__slider__hit-area, 24px);
+    height: var(--ember-primitives__slider__vertical-size, 10rem);
+  }
+
+  .ember-primitives__slider__track {
+    position: relative;
+    flex: 1;
+    height: var(--ember-primitives__slider__track-thickness, 4px);
+  }
+
+  .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__track {
+    height: auto;
+    width: var(--ember-primitives__slider__track-thickness, 4px);
+  }
+
+  .ember-primitives__slider__range {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+  }
+
+  .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__range {
+    top: auto;
+    bottom: auto;
+    left: 0;
+    right: 0;
+  }
+
+  /*
+    The native input is stretched across the whole track, invisible, and only
+    used for interaction. The visual thumb (a sibling) is what users see.
+  */
+  .ember-primitives__slider__thumb-input {
+    position: absolute;
+    left: 0;
+    top: 50%;
+    translate: 0 -50%;
+    width: 100%;
+    height: var(--ember-primitives__slider__hit-area, 24px);
+    margin: 0;
+    opacity: 0;
+    appearance: none;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  .ember-primitives__slider__thumb-input:disabled {
+    cursor: not-allowed;
+  }
+
+  .ember-primitives__slider__thumb-input[data-active] {
+    z-index: 2;
+  }
+
+  /*
+    Size the (invisible) native thumb to the hit area, so grabbing "the thumb"
+    feels right. These cannot be comma-combined: an unknown pseudo-element
+    invalidates the whole selector list in the other engine.
+  */
+  .ember-primitives__slider__thumb-input::-webkit-slider-thumb {
+    appearance: none;
+    width: var(--ember-primitives__slider__hit-area, 24px);
+    height: var(--ember-primitives__slider__hit-area, 24px);
+  }
+
+  .ember-primitives__slider__thumb-input::-moz-range-thumb {
+    border: none;
+    width: var(--ember-primitives__slider__hit-area, 24px);
+    height: var(--ember-primitives__slider__hit-area, 24px);
+  }
+
+  /*
+    Multi-thumb sliders overlap multiple full-width range inputs. If the
+    inputs themselves receive pointer events, the top-most input steals
+    clicks/drags from the other thumbs. Disable pointer events on the
+    track-sized input and re-enable them on the native thumb only.
+
+    Single-thumb sliders keep the whole input interactive, so clicking
+    anywhere on the track jumps to that value.
+  */
+  .ember-primitives__slider[data-multi] .ember-primitives__slider__thumb-input {
+    pointer-events: none;
+  }
+
+  .ember-primitives__slider[data-multi] .ember-primitives__slider__thumb-input::-webkit-slider-thumb {
+    pointer-events: auto;
+  }
+
+  .ember-primitives__slider[data-multi] .ember-primitives__slider__thumb-input::-moz-range-thumb {
+    pointer-events: auto;
+  }
+
+  /*
+    Vertical orientation: modern engines render a native vertical range input
+    with \`writing-mode\`. \`direction: rtl\` puts the minimum at the bottom.
+  */
+  .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__thumb-input {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    top: 0;
+    left: 50%;
+    translate: -50% 0;
+    width: var(--ember-primitives__slider__hit-area, 24px);
+    height: 100%;
+  }
+
+  /*
+    The visual thumb. The component positions it with an inline
+    \`left\`/\`bottom\` percentage; centering uses the \`translate\` property
+    (not \`transform\`) so consumer hover/active effects like
+    \`transform: scale(1.4)\` or \`scale: 1.4\` compose with it instead of
+    clobbering it.
+  */
+  .ember-primitives__slider__thumb {
+    position: absolute;
+    top: 50%;
+    translate: -50% -50%;
+    pointer-events: none;
+    z-index: 1;
+  }
+
+  .ember-primitives__slider__thumb[data-active] {
+    z-index: 3;
+  }
+
+  .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__thumb {
+    top: auto;
+    left: 50%;
+    translate: -50% 50%;
+  }
+
+  /*
+    Default appearance -- zero specificity via :where(), so any consumer rule
+    wins (even a layered one). Colors derive from currentColor so the slider
+    adapts to its context.
+  */
+  :where(.ember-primitives__slider__track) {
+    border-radius: calc(var(--ember-primitives__slider__track-thickness, 4px) / 2);
+    background: color-mix(in srgb, currentColor 20%, transparent);
+  }
+
+  :where(.ember-primitives__slider__range) {
+    border-radius: inherit;
+    background: currentColor;
+  }
+
+  :where(.ember-primitives__slider__thumb) {
+    width: var(--ember-primitives__slider__thumb-size, 16px);
+    height: var(--ember-primitives__slider__thumb-size, 16px);
+    border-radius: 50%;
+    background: currentColor;
+  }
+
+  :where(.ember-primitives__slider__thumb[data-disabled]) {
+    opacity: 0.5;
+  }
+
+  /* Keyboard focus is on the (invisible) input; reflect it on the visual thumb. */
+  :where(.ember-primitives__slider__thumb-input:focus-visible + .ember-primitives__slider__thumb) {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+}
+`;
+
+let sheet: CSSStyleSheet | null = null;
+
+function getSheet(): CSSStyleSheet | null {
+  if (typeof CSSStyleSheet === 'undefined') return null;
+
+  if (!sheet) {
+    sheet = new CSSStyleSheet();
+    sheet.replaceSync(styles);
+  }
+
+  return sheet;
+}
+
+/**
+ * Adds the slider's structural styles to whatever tree the slider is
+ * rendered in -- the document, or a containing shadow root (where
+ * document-level stylesheets can't reach).
+ *
+ * The stylesheet is shared: it is constructed once and adopted at most once
+ * per root.
+ */
+export const adoptStyles = modifier((element: Element) => {
+  const root = element.getRootNode();
+
+  if (!(root instanceof Document || root instanceof ShadowRoot)) return;
+
+  const styleSheet = getSheet();
+
+  if (!styleSheet) return;
+
+  if (!root.adoptedStyleSheets.includes(styleSheet)) {
+    root.adoptedStyleSheets = [...root.adoptedStyleSheets, styleSheet];
+  }
+});

--- a/test-app/tests/slider/rendering-test.gts
+++ b/test-app/tests/slider/rendering-test.gts
@@ -1,33 +1,33 @@
 import { tracked } from '@glimmer/tracking';
-import { click, render, rerender } from '@ember/test-helpers';
+import { fillIn, render, rerender } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
 import { Slider } from 'ember-primitives';
 
+const slider = '.ember-primitives__slider';
+const track = '.ember-primitives__slider__track';
+const thumbInput = '.ember-primitives__slider__thumb-input';
+const thumb = '.ember-primitives__slider__thumb';
+
 module('<Slider />', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('renders simply', async function (assert) {
-    const handleChange = (v: number | number[]) => {
-      assert.step(String(v));
-    };
-
-    await render(<template><Slider @value={{43}} @onValueChange={{handleChange}} /></template>);
-
-    const slider = '[data-slider]';
-    const track = '[role="presentation"]';
-    const thumb = '[role="slider"]';
+  test('renders simply (without a block)', async function (assert) {
+    await render(<template><Slider @value={{43}} /></template>);
 
     assert.dom(slider).exists();
     assert.dom(track).exists();
-    assert.dom(thumb).exists();
+    assert.dom(thumbInput).exists({ count: 1 });
+    assert.dom(thumb).exists({ count: 1 });
     assert.dom(slider).hasAttribute('data-orientation', 'horizontal');
-    assert.dom(slider).hasAttribute('data-disabled', 'false');
-    assert.dom(thumb).hasAttribute('aria-valuemin', '0');
-    assert.dom(thumb).hasAttribute('aria-valuemax', '100');
-    assert.dom(thumb).hasAttribute('aria-valuenow', '43');
-    assert.dom(thumb).hasAttribute('aria-orientation', 'horizontal');
+    assert.dom(slider).doesNotHaveAttribute('data-disabled');
+    assert.dom(slider).doesNotHaveAttribute('data-multi');
+    assert.dom(thumbInput).hasAttribute('min', '0');
+    assert.dom(thumbInput).hasAttribute('max', '100');
+    assert.dom(thumbInput).hasValue('43');
+    assert.dom(thumbInput).hasAria('label', 'Value');
+    assert.dom(thumb).hasAttribute('style', 'left: 43%');
   });
 
   test('renders with default single value', async function (assert) {
@@ -36,27 +36,21 @@ module('<Slider />', function (hooks) {
         <Slider as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const slider = '[data-slider]';
-    const track = '[role="presentation"]';
-    const thumb = '[role="slider"]';
-
     assert.dom(slider).exists();
     assert.dom(track).exists();
-    assert.dom(thumb).exists();
-    assert.dom(slider).hasAttribute('data-orientation', 'horizontal');
-    assert.dom(slider).hasAttribute('data-disabled', 'false');
-    assert.dom(thumb).hasAttribute('aria-valuemin', '0');
-    assert.dom(thumb).hasAttribute('aria-valuemax', '100');
-    assert.dom(thumb).hasAttribute('aria-valuenow', '0');
-    assert.dom(thumb).hasAttribute('aria-orientation', 'horizontal');
+    assert.dom(thumbInput).exists({ count: 1 });
+    assert.dom(thumb).exists({ count: 1 });
+    assert.dom(thumbInput).hasAttribute('min', '0');
+    assert.dom(thumbInput).hasAttribute('max', '100');
+    assert.dom(thumbInput).hasValue('0');
   });
 
   test('renders with a custom value', async function (assert) {
@@ -71,22 +65,22 @@ module('<Slider />', function (hooks) {
         <Slider @value={{state.value}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const thumb = '[role="slider"]';
-
-    assert.dom(thumb).hasAttribute('aria-valuenow', '50');
+    assert.dom(thumbInput).hasValue('50');
+    assert.dom(thumb).hasAttribute('style', 'left: 50%');
 
     state.value = 75;
     await rerender();
 
-    assert.dom(thumb).hasAttribute('aria-valuenow', '75');
+    assert.dom(thumbInput).hasValue('75');
+    assert.dom(thumb).hasAttribute('style', 'left: 75%');
   });
 
   test('renders with custom min, max, and step', async function (assert) {
@@ -95,40 +89,36 @@ module('<Slider />', function (hooks) {
         <Slider @value={{50}} @min={{10}} @max={{200}} @step={{5}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const thumb = '[role="slider"]';
-
-    assert.dom(thumb).hasAttribute('aria-valuemin', '10');
-    assert.dom(thumb).hasAttribute('aria-valuemax', '200');
-    assert.dom(thumb).hasAttribute('aria-valuenow', '50');
+    assert.dom(thumbInput).hasAttribute('min', '10');
+    assert.dom(thumbInput).hasAttribute('max', '200');
+    assert.dom(thumbInput).hasAttribute('step', '5');
+    assert.dom(thumbInput).hasValue('50');
   });
 
   test('renders with vertical orientation', async function (assert) {
     await render(
       <template>
-        <Slider @orientation="vertical" as |s|>
+        <Slider @value={{40}} @orientation="vertical" as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const slider = '[data-slider]';
-    const thumb = '[role="slider"]';
-
     assert.dom(slider).hasAttribute('data-orientation', 'vertical');
-    assert.dom(thumb).hasAttribute('aria-orientation', 'vertical');
+    assert.dom(thumb).hasAttribute('style', 'bottom: 40%');
   });
 
   test('renders with disabled state', async function (assert) {
@@ -137,20 +127,17 @@ module('<Slider />', function (hooks) {
         <Slider @disabled={{true}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const slider = '[data-slider]';
-    const thumb = '[role="slider"]';
-
-    assert.dom(slider).hasAttribute('data-disabled', 'true');
-    assert.dom(thumb).hasAttribute('aria-disabled', 'true');
-    assert.dom(thumb).hasAttribute('tabindex', '-1');
+    assert.dom(slider).hasAttribute('data-disabled');
+    assert.dom(thumbInput).isDisabled();
+    assert.dom(thumb).hasAttribute('data-disabled');
   });
 
   test('renders with multiple values (range)', async function (assert) {
@@ -161,52 +148,144 @@ module('<Slider />', function (hooks) {
         <Slider @value={{rangeValue}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const thumbs = '[role="slider"]';
+    assert.dom(slider).hasAttribute('data-multi');
+    assert.dom(thumbInput).exists({ count: 2 });
+    assert.dom(thumb).exists({ count: 2 });
 
-    assert.dom(thumbs).exists({ count: 2 });
+    const [input1, input2] = document.querySelectorAll<HTMLInputElement>(thumbInput);
 
-    const [thumb1, thumb2] = Array.from(document.querySelectorAll(thumbs));
-
-    assert.strictEqual(thumb1.getAttribute('aria-valuenow'), '20');
-    assert.strictEqual(thumb2.getAttribute('aria-valuenow'), '80');
+    assert.strictEqual(input1?.value, '20');
+    assert.strictEqual(input2?.value, '80');
   });
 
-  test('calls onValueChange callback', async function (assert) {
-    const handleChange = (value: number[]) => {
-      assert.step('onValueChange');
+  test('calls onValueChange and onValueCommit when a thumb moves', async function (assert) {
+    class State {
+      @tracked value = 50;
+    }
+
+    const state = new State();
+
+    const handleChange = (value: number | number[]) => {
+      assert.step(`change:${value}`);
+      state.value = value as number;
+    };
+
+    const handleCommit = (value: number | number[]) => {
+      assert.step(`commit:${value}`);
     };
 
     await render(
       <template>
-        <Slider @value={{50}} @onValueChange={{handleChange}} as |s|>
+        <Slider
+          @value={{state.value}}
+          @onValueChange={{handleChange}}
+          @onValueCommit={{handleCommit}}
+          as |s|
+        >
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    // Note: Testing actual pointer/keyboard interaction would require more setup
-    // This test verifies the component accepts the callback
-    assert.strictEqual(typeof handleChange, 'function');
+    await fillIn(thumbInput, '60');
+
+    // fillIn fires `input` and then `change`
+    assert.verifySteps(['change:60', 'change:60', 'commit:60']);
+    assert.strictEqual(state.value, 60);
+  });
+
+  test('thumbs cannot cross each other', async function (assert) {
+    class State {
+      @tracked value = [20, 80];
+    }
+
+    const state = new State();
+
+    const handleChange = (value: number | number[]) => {
+      state.value = value as number[];
+    };
+
+    await render(
+      <template>
+        <Slider @value={{state.value}} @onValueChange={{handleChange}} as |s|>
+          <s.Track>
+            <s.Range />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
+            {{/each}}
+          </s.Track>
+        </Slider>
+      </template>
+    );
+
+    const firstInput = document.querySelector<HTMLInputElement>(thumbInput);
+
+    assert.ok(firstInput, 'first thumb input exists');
+
+    // try to drag the lower thumb past the upper thumb
+    await fillIn(firstInput as HTMLInputElement, '95');
+
+    assert.deepEqual(state.value, [80, 80], 'lower thumb is constrained by the upper thumb');
+  });
+
+  test('supports discrete tick values via an array @step', async function (assert) {
+    const ticks = [0, 10, 20, 30, 40, 50];
+
+    class State {
+      @tracked value = 20;
+    }
+
+    const state = new State();
+
+    const handleChange = (value: number | number[]) => {
+      state.value = value as number;
+    };
+
+    await render(
+      <template>
+        <Slider @value={{state.value}} @step={{ticks}} @onValueChange={{handleChange}} as |s|>
+          <s.Track>
+            <s.Range />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
+            {{/each}}
+          </s.Track>
+        </Slider>
+      </template>
+    );
+
+    // internally, the input works on tick indices
+    assert.dom(thumbInput).hasAttribute('min', '0');
+    assert.dom(thumbInput).hasAttribute('max', '5');
+    assert.dom(thumbInput).hasAttribute('step', '1');
+    assert.dom(thumbInput).hasValue('2');
+
+    // moving to index 4 emits the tick value (40)
+    await fillIn(thumbInput, '4');
+
+    assert.strictEqual(state.value, 40);
   });
 
   test('exposes values, min, max, step', async function (assert) {
     await render(
       <template>
         <Slider @value={{50}} @min={{0}} @max={{100}} @step={{10}} as |s|>
-          <div data-test-values>{{s.values}}</div>
+          <div data-test-values>
+            {{#each s.values as |value|}}{{value}}{{/each}}
+          </div>
           <div data-test-min>{{s.min}}</div>
           <div data-test-max>{{s.max}}</div>
           <div data-test-step>{{s.step}}</div>
@@ -226,18 +305,16 @@ module('<Slider />', function (hooks) {
         <Slider @value={{150}} @min={{0}} @max={{100}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const thumb = '[role="slider"]';
-
     // Value should be clamped to max
-    assert.dom(thumb).hasAttribute('aria-valuenow', '100');
+    assert.dom(thumbInput).hasValue('100');
   });
 
   test('rounds values to step', async function (assert) {
@@ -246,17 +323,15 @@ module('<Slider />', function (hooks) {
         <Slider @value={{53}} @step={{10}} as |s|>
           <s.Track>
             <s.Range />
-            {{#each s.values as |value index|}}
-              <s.Thumb @value={{value}} @index={{index}} />
+            {{#each s.thumbs as |t|}}
+              <s.Thumb @thumb={{t}} aria-label="Value" />
             {{/each}}
           </s.Track>
         </Slider>
       </template>
     );
 
-    const thumb = '[role="slider"]';
-
     // Value should be rounded to nearest step (50)
-    assert.dom(thumb).hasAttribute('aria-valuenow', '50');
+    assert.dom(thumbInput).hasValue('50');
   });
 });


### PR DESCRIPTION
Targets #654's branch. This tries to resolve the blocker noted in [the hold-up comment](https://github.com/universal-ember/ember-primitives/pull/654#issuecomment-4106796199) — "how to make this UI pattern not annoying (esp w/r/t CSS)" — and gets CI green.

## The diagnosis

Every consumer (and every docs demo) had to hand-write ~100 lines of *structural* CSS per usage — invisible `opacity: 0` inputs, the `pointer-events: none` / `::-webkit-slider-thumb { pointer-events: auto }` dance for multi-thumb, the `rotate(-90deg) translateX(...)` vertical hack, z-index management for the active thumb — plus manually pair each invisible `<s.Thumb>` with a separately-positioned visual `<div>` via `htmlSafe (concat "left: " thumb.percent "%")`. The docs page had 3 slightly-different copies of this boilerplate.

## The fix

**The component now owns the structural CSS.** Consumers only write appearance:

```gjs
<Slider @value={{value.current}} @onValueChange={{value.set}} />

<style>
  .ember-primitives__slider { color: #1a73e8; }
</style>
```

- **`<s.Thumb>` renders the visual thumb too** — positioned along the track for you, with a block rendered inside it (tooltips/labels move with the thumb for free). No more `htmlSafe`/`concat`. `<s.Thumb @thumb={{thumb}} aria-label="...">` is the whole loop body.
- **Styles attach via `adoptedStyleSheets`** on the slider's root node, so they work inside shadow roots too (the docs demos are all `<Shadowed>` — a plain css file import would never reach them).
- **Everything is in `@layer ember-primitives`**, and appearance defaults use `:where()` + `currentColor` — any unlayered consumer rule wins regardless of specificity, but a bare `<Slider />` still looks reasonable out of the box (relates to #636).
- **Vertical uses `writing-mode: vertical-lr; direction: rtl`** on the native input instead of the rotation hack — no fixed-dimension CSS vars needed, and ArrowUp natively increases the value.
- **Thumb centering uses the `translate` property** (not `transform`), so consumer hover effects like `scale: 1.4` compose instead of clobbering positioning.
- Single-thumb sliders keep the whole input interactive (click-track-to-jump); only `[data-multi]` sliders get the pointer-events routing.

The docs demos shrink accordingly (net −591 lines across the PR) — `demo-styles.gjs` went from 180 lines of structural workarounds to ~80 lines of colors/tooltips, and the three divergent copies of the technique in `slider.gjs.md` are gone.

## CI fixes

- `test-app/tests/slider/rendering-test.gts` targeted an older span+ARIA API (`[data-slider]`, `role="slider"`, `aria-valuenow`) and had 4 type errors — this is what was failing Lint, all `typescript@*` jobs, and all `ember-*` try scenarios. Rewritten against the real DOM, with real interaction coverage (`fillIn`-driven `onValueChange`/`onValueCommit`, thumb-crossing constraint, tick-value mapping).
- The docs gallery imported `#public/3-ui/slider/gallery`, which isn't a defined import alias (only `#src`/`#docs` exist) — the slider docs page failed to compile at all. Now `#docs/...`.

## Verified

- `pnpm build`, `pnpm lint`, and the full test-app + docs-app suites pass locally (the only remaining local failures are 4 pre-existing `<InViewport>` ones that also fail on the unmodified branch and pass in CI/on main).
- Drove the docs app in a real browser: horizontal/vertical/multi-thumb all work with trusted pointer + keyboard input — including grabbing the *middle* thumb of three overlapping inputs, and ArrowUp increasing a vertical slider. The a11y tree exposes each thumb as a native slider with correct label/orientation/value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)