### PR TITLE
Slider: replace adopted-stylesheet modifier with a static CSS import

### DIFF
--- a/docs-app/app/templates/3-ui/slider.gjs.md
+++ b/docs-app/app/templates/3-ui/slider.gjs.md
@@ -933,7 +933,7 @@ Each `<s.Thumb>` renders two elements: an invisible native `<input type="range">
 
 ## Styling
 
-Structural CSS ships with the component. It is attached via [`adoptedStyleSheets`](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) on the root the slider renders into, so it also works inside shadow roots. Everything lives in `@layer ember-primitives`, and appearance defaults additionally use `:where()` (zero specificity) and derive from `currentColor` -- any rule you write overrides them, so styling can be as simple as:
+Structural CSS ships with the component as a regular stylesheet (bundled with your app's CSS), so it is present at first paint -- there is no runtime style injection. Everything lives in `@layer ember-primitives`, and appearance defaults additionally use `:where()` (zero specificity) and derive from `currentColor` -- any rule you write overrides them, so styling can be as simple as:
 
 ```css
 .ember-primitives__slider {
@@ -943,6 +943,8 @@ Structural CSS ships with the component. It is attached via [`adoptedStyleSheets
 ```
 
 The demos on this page each scope their appearance CSS with a prelude-less [`@scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope) block, which scopes rules to the `<style>` tag's parent element -- style isolation without shadow DOM (and without shadow DOM's focus-navigation quirks).
+
+If you render the slider inside a shadow root, document-level stylesheets won't reach it -- bring `ember-primitives/dist/components/slider.css` into the shadow tree yourself (e.g. `@import` it, or adopt it).
 
 The visual thumb is centered using the CSS `translate` property, so hover/active effects using `scale` or `transform` compose with it instead of clobbering the positioning:
 

--- a/ember-primitives/src/components/slider.css
+++ b/ember-primitives/src/components/slider.css
@@ -1,5 +1,3 @@
-import { modifier } from 'ember-modifier';
-
 /**
  * Structural styles for <Slider>.
  *
@@ -17,9 +15,10 @@ import { modifier } from 'ember-modifier';
  * Everything is wrapped in `@layer ember-primitives`, so *any* unlayered
  * consumer rule overrides these -- regardless of specificity or order.
  *
- * These styles are attached via `document.adoptedStyleSheets` (or the
- * containing ShadowRoot's) rather than a css file, so the component works
- * inside shadow roots, where document-level stylesheets don't reach.
+ * This is a plain stylesheet (bundled like any other CSS), so styles are
+ * present at first layout -- no waiting on a render cycle. If you render
+ * the slider inside a shadow root, bring this stylesheet into that root
+ * yourself (e.g. adopt it, or @import it in the shadow tree).
  *
  * Knobs:
  *   --ember-primitives__slider__hit-area         pointer target size (default 24px)
@@ -27,7 +26,6 @@ import { modifier } from 'ember-modifier';
  *   --ember-primitives__slider__track-thickness  rail thickness (default 4px)
  *   --ember-primitives__slider__vertical-size    length of a vertical slider (default 10rem)
  */
-const styles = /* css */ `
 @layer ember-primitives {
   .ember-primitives__slider {
     position: relative;
@@ -123,7 +121,8 @@ const styles = /* css */ `
     pointer-events: none;
   }
 
-  .ember-primitives__slider[data-multi] .ember-primitives__slider__thumb-input::-webkit-slider-thumb {
+  .ember-primitives__slider[data-multi]
+    .ember-primitives__slider__thumb-input::-webkit-slider-thumb {
     pointer-events: auto;
   }
 
@@ -133,7 +132,7 @@ const styles = /* css */ `
 
   /*
     Vertical orientation: modern engines render a native vertical range input
-    with \`writing-mode\`. \`direction: rtl\` puts the minimum at the bottom.
+    with `writing-mode`. `direction: rtl` puts the minimum at the bottom.
   */
   .ember-primitives__slider[data-orientation="vertical"] .ember-primitives__slider__thumb-input {
     writing-mode: vertical-lr;
@@ -147,9 +146,9 @@ const styles = /* css */ `
 
   /*
     The visual thumb. The component positions it with an inline
-    \`left\`/\`bottom\` percentage; centering uses the \`translate\` property
-    (not \`transform\`) so consumer hover/active effects like
-    \`transform: scale(1.4)\` or \`scale: 1.4\` compose with it instead of
+    `left`/`bottom` percentage; centering uses the `translate` property
+    (not `transform`) so consumer hover/active effects like
+    `transform: scale(1.4)` or `scale: 1.4` compose with it instead of
     clobbering it.
   */
   .ember-primitives__slider__thumb {
@@ -202,39 +201,3 @@ const styles = /* css */ `
     outline-offset: 2px;
   }
 }
-`;
-
-let sheet: CSSStyleSheet | null = null;
-
-function getSheet(): CSSStyleSheet | null {
-  if (typeof CSSStyleSheet === 'undefined') return null;
-
-  if (!sheet) {
-    sheet = new CSSStyleSheet();
-    sheet.replaceSync(styles);
-  }
-
-  return sheet;
-}
-
-/**
- * Adds the slider's structural styles to whatever tree the slider is
- * rendered in -- the document, or a containing shadow root (where
- * document-level stylesheets can't reach).
- *
- * The stylesheet is shared: it is constructed once and adopted at most once
- * per root.
- */
-export const adoptStyles = modifier((element: Element) => {
-  const root = element.getRootNode();
-
-  if (!(root instanceof Document || root instanceof ShadowRoot)) return;
-
-  const styleSheet = getSheet();
-
-  if (!styleSheet) return;
-
-  if (!root.adoptedStyleSheets.includes(styleSheet)) {
-    root.adoptedStyleSheets = [...root.adoptedStyleSheets, styleSheet];
-  }
-});

--- a/ember-primitives/src/components/slider.gts
+++ b/ember-primitives/src/components/slider.gts
@@ -1,9 +1,10 @@
+import "./slider.css";
+
 import Component from "@glimmer/component";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 
 import { SliderStore, type SliderThumb, type StyleString } from "./slider/store.ts";
-import { adoptStyles } from "./slider/style.ts";
 
 import type { TOC } from "@ember/component/template-only";
 import type Owner from "@ember/owner";
@@ -245,7 +246,6 @@ export class Slider extends Component<Signature> {
       data-orientation={{this.store.orientation}}
       data-disabled={{if this.store.disabled ""}}
       data-multi={{if this.store.isMulti ""}}
-      {{adoptStyles}}
     >
       {{#if (has-block)}}
         {{yield


### PR DESCRIPTION
Follow-up to #654 / #772.

The slider's structural styles were attached at runtime by a modifier that pushed a constructable stylesheet into the render root's `adoptedStyleSheets`. That means the slider's first render happens unstyled and the browser has to recalc styles / reflow once the sheet is adopted after render.

This ships them as a plain stylesheet instead — `import "./slider.css"` in `slider.gts`, the same convention as `hero.css` / `sticky-footer.css` — so the rules are bundled with the app's CSS and present at first layout, with no runtime injection and no modifier.

- CSS content is unchanged: still wrapped in `@layer ember-primitives`, appearance defaults still `:where()` + `currentColor`.
- `slider/style.ts` (the modifier + constructable-sheet plumbing) is deleted; net −35 lines.
- The docs demos are unaffected — they render in light DOM (since #772's `@scope` change). Consumers who render the slider inside a shadow root now need to bring `ember-primitives/dist/components/slider.css` into that root themselves; this is documented in the Styling section.

Verified: build emits `dist/components/slider.css` with the import preserved in `dist/components/slider.js`; lint green; all 13 slider rendering tests pass; drove the docs app — all 26 sliders styled from the stylesheet with `document.adoptedStyleSheets.length === 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)