### PR TITLE
which-heading-do-i-need: nested sections are not heading context; heading-less boundaries are transparent

### DIFF
--- a/packages/which-heading-do-i-need/src/index.ts
+++ b/packages/which-heading-do-i-need/src/index.ts
@@ -13,6 +13,18 @@ const BOUNDARY_ELEMENTS = new Set([
 ]);
 
 /**
+ * The subset of BOUNDARY_ELEMENTS that starts a new section of its own
+ * ([sectioning content][mdn-sc]).
+ *
+ * The others (header, footer, main) belong to the section they are in --
+ * in particular, a <header> typically *contains* its section's heading,
+ * so traversal must be able to look inside it.
+ *
+ * [mdn-sc]: https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content
+ */
+const SECTIONING_CONTENT = new Set(['SECTION', 'ARTICLE', 'ASIDE', 'NAV']);
+
+/**
  * A set with both cases is more performant than calling toLowerCase
  */
 const SECTION_HEADINGS = new Set([
@@ -96,9 +108,15 @@ function findHeadingIn(
    * Fallback traversal if we still haven't found the
    * heading level, we check all the children
    * of the current node, because headings can be
-   * within <a> tags and such.
+   * within <a> tags, <header>s, and such.
+   *
+   * Like the previous-sibling traversal above, this does not descend
+   * into sectioning content: headings within a nested <section> (etc)
+   * belong to that section, and are not context for our heading.
    */
   for (const child of node.children) {
+    if (SECTIONING_CONTENT.has(child.tagName)) continue;
+
     const level = findHeadingIn(child);
 
     if (level) return level;
@@ -160,7 +178,7 @@ function levelOf(node: Text): Level {
     return 1;
   }
 
-  const stopAt = nearestAncestor(ourBoundary, (el) => {
+  let stopAt = nearestAncestor(ourBoundary, (el) => {
     if (BOUNDARY_ELEMENTS.has(el.tagName)) return true;
 
     return isRoot(el);
@@ -182,7 +200,25 @@ function levelOf(node: Text): Level {
       return (level + 1) as Level;
     }
 
-    if (current === stopAt) break;
+    if (current === stopAt) {
+      /**
+       * A boundary with no heading (between its start and our position)
+       * has no heading level of its own to nest under, so it is
+       * transparent: keep searching outward for context, rather than
+       * concluding <h1>.
+       */
+      if (current instanceof Element && !isRoot(current)) {
+        stopAt = nearestAncestor(current, (el) => {
+          if (BOUNDARY_ELEMENTS.has(el.tagName)) return true;
+
+          return isRoot(el);
+        });
+
+        if (!stopAt) break;
+      } else {
+        break;
+      }
+    }
 
     if (current instanceof ShadowRoot) {
       current = current.host;

--- a/test-app/tests/heading/unit-test.ts
+++ b/test-app/tests/heading/unit-test.ts
@@ -25,6 +25,55 @@ module('Unit | getSectionHeadingLevel', function () {
     assert.strictEqual(level, 4);
   });
 
+  test('heading-less sections are transparent (no reset to h1)', function (assert) {
+    const doc = `
+        <h2>
+          hello there
+        </h2>
+        <section>
+          <section>
+          </section>
+        </section>
+      `;
+
+    const root = document.createElement('div');
+
+    root.innerHTML = doc;
+
+    const ref = document.createTextNode('');
+
+    root.querySelector('section section')?.append(ref);
+
+    const level = getSectionHeadingLevel(ref);
+
+    assert.strictEqual(level, 3);
+  });
+
+  test('headings within sibling sections are not context', function (assert) {
+    const doc = `
+        <h2>
+          hello there
+        </h2>
+        <section>
+          <h3>a sibling section's heading</h3>
+        </section>
+        <section>
+        </section>
+      `;
+
+    const root = document.createElement('div');
+
+    root.innerHTML = doc;
+
+    const ref = document.createTextNode('');
+
+    root.querySelector('section + section')?.append(ref);
+
+    const level = getSectionHeadingLevel(ref);
+
+    assert.strictEqual(level, 3);
+  });
+
   test('no existing heading', function (assert) {
     const doc = `
         <section>


### PR DESCRIPTION
Fixes two ways `getSectionHeadingLevel` (which-heading-do-i-need) disagreed with its own documented algorithm — *"We'll need to check the subtrees between these elements, **stopping if we encounter other boundary elements**"* — surfaced while fixing an axe `heading-order` failure via universal-ember/kolay#318 (see the review discussion there).

## 1. Fallback traversal recursed into sectioning content

`findHeadingIn`'s previous-sibling scan skips boundary siblings, but its fallback child-traversal recursed into **every** child, including nested `<section>`s. Headings inside a nested/sibling section belong to *that* section and are not context for ours, but the fallback found them anyway. Consequences:

- sibling headings behind non-boundary wrappers resolved one level deeper than the first heading, instead of equal;
- sibling `<section>`s cascaded one level per section (`h3, h4, h5, ...`).

The fallback now skips [sectioning content](https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#sectioning_content) (`section`, `article`, `aside`, `nav`) — consistent with the sibling scan. `header` / `footer` / `main` are still traversed: a `<header>` in particular typically *contains* its section's heading, which the existing "wrapped headings" rendering tests cover (a blanket boundary skip fails 4 of them; this split keeps them green).

## 2. Heading-less boundaries isolated their contents to `<h1>`

`levelOf` returned 1 as soon as the upward walk reached the next boundary, even when that boundary had no heading of its own. A heading-less wrapper `<section>` therefore cut everything inside it off from the document — kolay's api-docs signatures rendered `<h1>`s mid-page (a 2+ level heading-order jump on consuming docs pages, flagged by axe-core ≥ 4.12). A boundary without a heading has no level to nest under, so it is now transparent: the walk keeps searching outward for context.

```html
<h2>API Reference</h2>
<section>          <!-- no heading of its own -->
  <section>
    <Heading />    <!-- was: h1; now: h3 -->
  </section>
</section>
```

## Verification

- 2 new unit tests (heading-less sections are transparent; sibling-section headings are not context)
- full test-app suite: 388 pass / 0 heading failures — including all existing `wrapped headings`, `extraneous sections`, shadow-root, and mixed section/aside/article cases (4 `<InViewport />` failures in my local run are pre-existing: identical on an unmodified checkout, IntersectionObserver-timing related, untouched by this change)
- package lint: eslint, tsc, prettier all green
- downstream check: with this fix packed into kolay#318 and that packed into nvp.ui (floating deps, axe-core 4.12.1), all api-docs signature headings resolve as equal-level siblings one below the heading that precedes the block (e.g. `h2 API Reference → h3 Element / h3 Arguments / h3 Blocks`), union variants no longer cascade, and nvp.ui's full suite passes 83/83

🤖 Generated with [Claude Code](https://claude.com/claude-code)
