### PR TITLE
Add <Resizable> panel-group component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules/
 /.node_modules.ember-try/
 /package.json.ember-try
 /yarn.lock.ember-try
+
+# generated during docs-app test runs
+ember-a11y-report/

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -420,7 +420,7 @@ import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable'
 
 Panels are discovered from the DOM, so managing a layout is just managing what you render: `{{#each}}` over your own state, add or remove entries, nest a `<Resizable>` for a split.
 
-Click a panel to focus it (highlighted). **Add panel** inserts a sibling after the focused panel, **Split** wraps the focused panel in a new cross-oriented group (so further additions land *inside* the split), **Rotate** flips the focused panel's group, and **Remove** deletes the focused panel -- groups left with a single child dissolve.
+Click a panel to focus it (highlighted). **Add panel** inserts a sibling after the focused panel, **Split h** / **Split v** wrap the focused panel in a new group of that orientation -- dividing its space in half, with further additions landing *inside* the split -- **Rotate** flips the focused panel's group, and **Remove** deletes the focused panel -- groups left with a single child dissolve.
 
 <div class="featured-demo auto-height">
 
@@ -481,14 +481,14 @@ const addPanel = () => {
   focused.set(panel);
 };
 
-const split = () => {
+const split = (orientation) => {
   const target = focused.current;
   const parent = findParent(root, target);
 
   if (!parent) return;
 
   const panel = new PanelNode();
-  const group = new GroupNode(cross(parent.orientation), [target, panel]);
+  const group = new GroupNode(orientation, [target, panel]);
 
   parent.children.splice(parent.children.indexOf(target), 1, group);
   focused.set(panel);
@@ -544,7 +544,8 @@ const Tree = <template>
 <template>
   <div class="rz-dynamic-bar">
     <button type="button" {{on "click" addPanel}}>Add panel</button>
-    <button type="button" {{on "click" split}}>Split</button>
+    <button type="button" {{on "click" (fn split "horizontal")}}>Split h</button>
+    <button type="button" {{on "click" (fn split "vertical")}}>Split v</button>
     <button type="button" {{on "click" removePanel}}>Remove</button>
     <button type="button" {{on "click" rotate}}>Rotate</button>
     <span>
@@ -740,10 +741,9 @@ const Output = <template>
     /* in the narrow sliver, the whole button row rotates 90° to fit */
     .limber-minimized[data-orientation='horizontal'] .limber-controls {
       top: 0.375rem;
-      right: auto;
-      left: 100%;
-      transform: rotate(90deg);
-      transform-origin: top left;
+      right: 100%;
+      transform: rotate(-90deg);
+      transform-origin: top right;
     }
     .limber-minimized[data-orientation='vertical'] .limber-sliver {
       height: 2rem;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -66,8 +66,6 @@ Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab<
 
 ```gjs live preview no-shadow
 import { tracked } from '@glimmer/tracking';
-import { fn } from '@ember/helper';
-import { on } from '@ember/modifier';
 import { TrackedArray } from 'tracked-built-ins';
 import { Resizable } from 'ember-primitives';
 
@@ -97,8 +95,6 @@ class Split {
 }
 
 const isSplit = (node) => node instanceof Split;
-const eq = (a, b) => a === b;
-const gt = (a, b) => a > b;
 
 function findParent(node, target) {
   if (!isSplit(node)) return null;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -75,6 +75,13 @@ let launches = 0;
 
 class AppWindow {
   @tracked title;
+  /**
+   * Focus is a per-window flag (not a comparison against a shared
+   * `focused` value) so a focus change only invalidates the two
+   * windows involved -- every other window's class binding stays
+   * untouched, and observers see no writes on them.
+   */
+  @tracked isFocused = false;
   content;
 
   constructor() {
@@ -120,8 +127,17 @@ class WindowManager {
   root = new Split('horizontal', [new AppWindow()]);
   @tracked focused = firstWindow(this.root);
 
+  constructor() {
+    if (this.focused) this.focused.isFocused = true;
+  }
+
   focus = (node) => {
-    if (this.focused !== node) this.focused = node;
+    if (this.focused === node) return;
+
+    if (this.focused) this.focused.isFocused = false;
+    if (node) node.isFocused = true;
+
+    this.focused = node;
   };
 
   split = (orientation) => {
@@ -143,7 +159,7 @@ class WindowManager {
       parent.children.splice(parent.children.indexOf(focused), 1, wrapped);
     }
 
-    this.focused = win;
+    this.focus(win);
   };
 
   toggleLayout = () => {
@@ -175,7 +191,7 @@ class WindowManager {
       grandparent.children.splice(grandparent.children.indexOf(parent), 1, only);
     }
 
-    this.focused = firstWindow(parent.children.length ? parent : root);
+    this.focus(firstWindow(parent.children.length ? parent : root));
   };
 }
 
@@ -196,7 +212,7 @@ const Tree = <template>
   {{else}}
     <button
       type="button"
-      class="i3-window {{if (eq wm.focused @node) 'is-focused'}}"
+      class="i3-window {{if @node.isFocused 'is-focused'}}"
       {{on "click" (fn wm.focus @node)}}
     >
       <span class="i3-title">{{@node.title}}</span>
@@ -436,6 +452,13 @@ let nextId = 1;
 
 class PanelNode {
   id = nextId++;
+  /**
+   * A per-panel flag (rather than comparing against the shared
+   * `focused` value in the template) so a focus change only
+   * invalidates the two panels involved -- nothing is written to any
+   * other panel, not even a same-value `class`.
+   */
+  @tracked isFocused = false;
 }
 
 class GroupNode {
@@ -453,8 +476,16 @@ const cross = (orientation) => (orientation === 'horizontal' ? 'vertical' : 'hor
 
 const root = new GroupNode('horizontal', [new PanelNode(), new PanelNode()]);
 const focused = cell(root.children[0]);
+
+focused.current.isFocused = true;
+
 const focus = (panel) => {
-  if (focused.current !== panel) focused.set(panel);
+  if (focused.current === panel) return;
+
+  if (focused.current) focused.current.isFocused = false;
+  if (panel) panel.isFocused = true;
+
+  focused.set(panel);
 };
 
 function findParent(node, target) {
@@ -482,7 +513,7 @@ const addPanel = () => {
   const panel = new PanelNode();
 
   parent.children.splice(parent.children.indexOf(focused.current) + 1, 0, panel);
-  focused.set(panel);
+  focus(panel);
 };
 
 const split = (orientation) => {
@@ -495,7 +526,7 @@ const split = (orientation) => {
   const group = new GroupNode(orientation, [target, panel]);
 
   parent.children.splice(parent.children.indexOf(target), 1, group);
-  focused.set(panel);
+  focus(panel);
 };
 
 const removePanel = () => {
@@ -513,7 +544,7 @@ const removePanel = () => {
     grandparent.children.splice(grandparent.children.indexOf(parent), 1, parent.children[0]);
   }
 
-  focused.set(firstPanel(parent.children.length ? parent : root));
+  focus(firstPanel(parent.children.length ? parent : root));
 };
 
 const rotate = () => {
@@ -534,7 +565,7 @@ const Tree = <template>
         {{else}}
           <button
             type="button"
-            class="rz-pane {{if (eq focused.current child) 'is-focused'}}"
+            class="rz-pane {{if child.isFocused 'is-focused'}}"
             {{on "click" (fn focus child)}}
           >
             {{child.id}}

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -120,7 +120,9 @@ class WindowManager {
   root = new Split('horizontal', [new AppWindow()]);
   @tracked focused = firstWindow(this.root);
 
-  focus = (node) => (this.focused = node);
+  focus = (node) => {
+    if (this.focused !== node) this.focused = node;
+  };
 
   split = (orientation) => {
     const win = new AppWindow();
@@ -451,7 +453,9 @@ const cross = (orientation) => (orientation === 'horizontal' ? 'vertical' : 'hor
 
 const root = new GroupNode('horizontal', [new PanelNode(), new PanelNode()]);
 const focused = cell(root.children[0]);
-const focus = (panel) => focused.set(panel);
+const focus = (panel) => {
+  if (focused.current !== panel) focused.set(panel);
+};
 
 function findParent(node, target) {
   if (!isGroup(node)) return null;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -206,10 +206,10 @@ const Tree = <template>
 <template>
   <div class="i3">
     <div class="i3-bar">
-      <button type="button" {{on "click" (fn wm.split "horizontal")}}>$mod+Enter (split h)</button>
-      <button type="button" {{on "click" (fn wm.split "vertical")}}>$mod+v (split v)</button>
-      <button type="button" {{on "click" wm.toggleLayout}}>$mod+e (toggle layout)</button>
-      <button type="button" {{on "click" wm.kill}}>$mod+Shift+q (kill)</button>
+      <button type="button" {{on "click" (fn wm.split "horizontal")}}>split h</button>
+      <button type="button" {{on "click" (fn wm.split "vertical")}}>split v</button>
+      <button type="button" {{on "click" wm.toggleLayout}}>toggle layout</button>
+      <button type="button" {{on "click" wm.kill}}>kill</button>
       <span class="i3-status">1: {{if wm.focused wm.focused.title "(empty)"}}</span>
     </div>
     <div class="i3-workspace">

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -897,7 +897,7 @@ Dragging uses pointer capture, so resizing keeps working when the pointer passes
 
 The handle follows the [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern: it is a focusable `role="separator"` with `aria-valuenow/min/max` describing the panel before it.
 
-No ids are generated (ids are global), and `aria-controls` is not set -- assistive-technology support for it is poor, and the value/orientation semantics plus the handle's accessible name carry the useful information. If you want it anyway, set an `id` on your panel and `aria-controls` on the handle yourself.
+Each panel gets a stable, component-owned id (incrementing, not overridable -- it renders after `...attributes`), and each handle references the panel before it via `aria-controls`.
 
 Give each handle an accessible name (e.g. `aria-label="Resize sidebar"`).
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -897,7 +897,7 @@ Dragging uses pointer capture, so resizing keeps working when the pointer passes
 
 The handle follows the [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern: it is a focusable `role="separator"` with `aria-valuenow/min/max` describing the panel before it.
 
-No ids are generated (ids are global) -- but if you give a panel an `id`, the handle after it references it via `aria-controls`.
+No ids are generated (ids are global), and `aria-controls` is not set -- assistive-technology support for it is poor, and the value/orientation semantics plus the handle's accessible name carry the useful information. If you want it anyway, set an `id` on your panel and `aria-controls` on the handle yourself.
 
 Give each handle an accessible name (e.g. `aria-label="Resize sidebar"`).
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -895,7 +895,9 @@ Dragging uses pointer capture, so resizing keeps working when the pointer passes
 
 ## Accessibility
 
-The handle follows the [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern: it is a focusable `role="separator"` with `aria-valuenow/min/max` describing the panel before it (also referenced via `aria-controls`).
+The handle follows the [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern: it is a focusable `role="separator"` with `aria-valuenow/min/max` describing the panel before it.
+
+No ids are generated (ids are global) -- but if you give a panel an `id`, the handle after it references it via `aria-controls`.
 
 Give each handle an accessible name (e.g. `aria-label="Resize sidebar"`).
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -7,26 +7,26 @@ Each `<Resizable>` is a flat row (or column) of panels -- but a panel may contai
 <div class="featured-demo auto-height">
 
 ```gjs live preview no-shadow
-import { Resizable } from 'ember-primitives';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
 <template>
   <div class="rz-demo">
-    <Resizable as |r|>
-      <r.Panel @minSize={{15}} @defaultSize={{25}}>
+    <Resizable>
+      <Panel @minSize={{15}} @size={{25}}>
         <div class="rz-pane">sidebar</div>
-      </r.Panel>
-      <r.Handle aria-label="Resize sidebar" />
-      <r.Panel>
-        <Resizable @orientation="vertical" as |inner|>
-          <inner.Panel>
+      </Panel>
+      <Handle aria-label="Resize sidebar" />
+      <Panel>
+        <Resizable @orientation="vertical">
+          <Panel>
             <div class="rz-pane">editor</div>
-          </inner.Panel>
-          <inner.Handle aria-label="Resize terminal" />
-          <inner.Panel @minSize={{10}} @defaultSize={{30}} @collapsible={{true}}>
+          </Panel>
+          <Handle aria-label="Resize terminal" />
+          <Panel @minSize={{10}} @size={{30}} @collapsible={{true}}>
             <div class="rz-pane">terminal</div>
-          </inner.Panel>
+          </Panel>
         </Resizable>
-      </r.Panel>
+      </Panel>
     </Resizable>
   </div>
   <style>
@@ -67,7 +67,7 @@ Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab<
 ```gjs live preview no-shadow
 import { tracked } from '@glimmer/tracking';
 import { trackedArray } from '@ember/reactive/collections';
-import { Resizable } from 'ember-primitives';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
 const PROGRAMS = ['URxvt', 'firefox', 'emacs', 'htop', 'ncmpcpp', 'ranger', 'weechat', 'neomutt'];
 const PROMPTS = ['~ $ ', '~/dev $ make', '*scratch*', 'MEM 42%', '♫ paused', '~/…/photos', '#ember', 'INBOX (3)'];
@@ -171,14 +171,14 @@ const wm = new WindowManager();
 
 const Tree = <template>
   {{#if (isSplit @node)}}
-    <Resizable @orientation={{@node.orientation}} as |r|>
+    <Resizable @orientation={{@node.orientation}}>
       {{#each @node.children as |child index|}}
         {{#if (gt index 0)}}
-          <r.Handle aria-label="Resize window" />
+          <Handle aria-label="Resize window" />
         {{/if}}
-        <r.Panel @minSize={{5}}>
+        <Panel @minSize={{5}}>
           <Tree @node={{child}} />
-        </r.Panel>
+        </Panel>
       {{/each}}
     </Resizable>
   {{else}}
@@ -296,48 +296,125 @@ const Tree = <template>
 
 </div>
 
-## Install
+## Changing orientation
 
-```bash
-pnpm add ember-primitives
-```
+`@orientation` may change while rendered -- panels keep their proportions and re-flow along the new axis.
 
-```js
-import { Resizable } from 'ember-primitives';
-// or
-import { Resizable } from 'ember-primitives/components/resizable';
-```
+<div class="featured-demo auto-height">
 
-## Anatomy
+```gjs live preview no-shadow
+import { cell } from 'ember-resources';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
-```gjs
-import { Resizable } from 'ember-primitives';
+const orientation = cell('horizontal');
+const toggle = () =>
+  orientation.set(orientation.current === 'horizontal' ? 'vertical' : 'horizontal');
 
 <template>
-  <Resizable @orientation="horizontal" as |r|>
-    <r.Panel>…</r.Panel>
-    <r.Handle aria-label="Resize" />
-    <r.Panel>
-      {{! panels may contain another <Resizable> }}
-    </r.Panel>
-  </Resizable>
+  <button type="button" {{on "click" toggle}}>
+    Rotate ({{orientation.current}})
+  </button>
+
+  <div class="rz-orientation">
+    <Resizable @orientation={{orientation.current}}>
+      <Panel><div class="rz-pane">one</div></Panel>
+      <Handle aria-label="Resize one" />
+      <Panel><div class="rz-pane">two</div></Panel>
+      <Handle aria-label="Resize two" />
+      <Panel><div class="rz-pane">three</div></Panel>
+    </Resizable>
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .rz-orientation {
+      height: 200px;
+      margin-top: 0.5rem;
+      border: 1px solid gray;
+    }
+    .rz-orientation .rz-pane {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+    }
+    .rz-orientation .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .rz-orientation .ember-primitives__resizable__handle:hover,
+    .rz-orientation .ember-primitives__resizable__handle:focus-visible,
+    .rz-orientation .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
 </template>
 ```
 
-A `Handle` resizes the two panels on either side of it. Sizes are percentages of the group's space, applied via `flex-grow` -- the component ships only the structural CSS (flex layout, cursors, `touch-action`); all appearance (handle color, width, hover/focus styles) is up to you.
+</div>
 
-Dragging uses pointer capture, so resizing keeps working when the pointer passes over iframes -- no overlay element needed.
+## Collapsing
+
+A `@collapsible` panel can be closed entirely: press <kbd>Enter</kbd> on its handle to collapse or restore it, or drag well past its `@minSize` to snap it closed (within `@minSize` it holds at the minimum). While collapsed, the panel has a `data-collapsed` attribute you can style.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
+
+<template>
+  <div class="rz-collapse">
+    <Resizable>
+      <Panel @collapsible={{true}} @minSize={{20}} @size={{30}}>
+        <div class="rz-pane">sidebar<br /><small>(collapsible)</small></div>
+      </Panel>
+      <Handle aria-label="Resize or collapse sidebar" />
+      <Panel><div class="rz-pane">content</div></Panel>
+    </Resizable>
+  </div>
+  <p><small>Focus the handle and press <kbd>Enter</kbd>, or drag it all the way left.</small></p>
+  <style>
+    /* styles for the demo, not required */
+    .rz-collapse {
+      height: 180px;
+      border: 1px solid gray;
+    }
+    .rz-collapse .rz-pane {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+      text-align: center;
+    }
+    .rz-collapse [data-collapsed] {
+      border-right: 4px solid dodgerblue;
+    }
+    .rz-collapse .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .rz-collapse .ember-primitives__resizable__handle:hover,
+    .rz-collapse .ember-primitives__resizable__handle:focus-visible,
+    .rz-collapse .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
+</template>
+```
+
+</div>
 
 ## Persisting the layout
 
-`@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@defaultSize` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
+`@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@size` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
 
 With nested groups, each group persists its own sizes under its own key. Resize the panels below, then reload the page -- the layout is remembered.
 
 <div class="featured-demo auto-height">
 
 ```gjs live preview no-shadow
-import { Resizable } from 'ember-primitives';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
 const KEY = 'docs:resizable:persisted-demo';
 
@@ -360,22 +437,22 @@ const sizeOf = (group, index) => saved[group]?.[index];
 
 <template>
   <div class="rz-persisted">
-    <Resizable @onLayoutChange={{persist "outer"}} as |r|>
-      <r.Panel @defaultSize={{sizeOf "outer" 0}} @minSize={{15}}>
+    <Resizable @onLayoutChange={{persist "outer"}}>
+      <Panel @size={{sizeOf "outer" 0}} @minSize={{15}}>
         <div class="rz-pane">files</div>
-      </r.Panel>
-      <r.Handle aria-label="Resize files" />
-      <r.Panel @defaultSize={{sizeOf "outer" 1}}>
-        <Resizable @orientation="vertical" @onLayoutChange={{persist "inner"}} as |inner|>
-          <inner.Panel @defaultSize={{sizeOf "inner" 0}}>
+      </Panel>
+      <Handle aria-label="Resize files" />
+      <Panel @size={{sizeOf "outer" 1}}>
+        <Resizable @orientation="vertical" @onLayoutChange={{persist "inner"}}>
+          <Panel @size={{sizeOf "inner" 0}}>
             <div class="rz-pane">editor</div>
-          </inner.Panel>
-          <inner.Handle aria-label="Resize output" />
-          <inner.Panel @defaultSize={{sizeOf "inner" 1}} @minSize={{10}}>
+          </Panel>
+          <Handle aria-label="Resize output" />
+          <Panel @size={{sizeOf "inner" 1}} @minSize={{10}}>
             <div class="rz-pane">output</div>
-          </inner.Panel>
+          </Panel>
         </Resizable>
-      </r.Panel>
+      </Panel>
     </Resizable>
   </div>
   <style>
@@ -405,6 +482,40 @@ const sizeOf = (group, index) => saved[group]?.[index];
 ```
 
 </div>
+
+## Install
+
+```bash
+pnpm add ember-primitives
+```
+
+```js
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
+// or, from the barrel:
+import { Resizable, ResizablePanel, ResizableHandle } from 'ember-primitives';
+```
+
+## Anatomy
+
+```gjs
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
+
+<template>
+  <Resizable @orientation="horizontal">
+    <Panel>…</Panel>
+    <Handle aria-label="Resize" />
+    <Panel>
+      {{! panels may contain another <Resizable> }}
+    </Panel>
+  </Resizable>
+</template>
+```
+
+`Panel` and `Handle` are their own imports and find their group through the DOM: panels declare their constraints as data attributes the group queries for, and handles locate the group's state via DOM context. There is no registration -- what's in the DOM *is* the layout.
+
+A `Handle` resizes the two panels on either side of it. Sizes are percentages of the group's space, applied via `flex-grow` -- the component ships only the structural CSS (flex layout, cursors, `touch-action`); all appearance (handle color, width, hover/focus styles) is up to you.
+
+Dragging uses pointer capture, so resizing keeps working when the pointer passes over iframes -- no overlay element needed.
 
 ## Accessibility
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -57,7 +57,7 @@ import { Resizable } from 'ember-primitives';
 
 </div>
 
-## i3, but it's a demo
+## i3: a tree-based window manager
 
 Because groups nest, a whole tiling window manager layout is just a tree of `<Resizable>`s.
 Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab</kbd> to the borders to resize.
@@ -331,6 +331,80 @@ Dragging uses pointer capture, so resizing keeps working when the pointer passes
 ## Persisting the layout
 
 `@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@defaultSize` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
+
+With nested groups, each group persists its own sizes under its own key. Resize the panels below, then reload the page -- the layout is remembered.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { Resizable } from 'ember-primitives';
+
+const KEY = 'docs:resizable:persisted-demo';
+
+function load() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) ?? {};
+  } catch {
+    return {};
+  }
+}
+
+const saved = load();
+
+const persist = (group) => (sizes) => {
+  saved[group] = sizes;
+  localStorage.setItem(KEY, JSON.stringify(saved));
+};
+
+const sizeOf = (group, index) => saved[group]?.[index];
+
+<template>
+  <div class="rz-persisted">
+    <Resizable @onLayoutChange={{persist "outer"}} as |r|>
+      <r.Panel @defaultSize={{sizeOf "outer" 0}} @minSize={{15}}>
+        <div class="rz-pane">files</div>
+      </r.Panel>
+      <r.Handle aria-label="Resize files" />
+      <r.Panel @defaultSize={{sizeOf "outer" 1}}>
+        <Resizable @orientation="vertical" @onLayoutChange={{persist "inner"}} as |inner|>
+          <inner.Panel @defaultSize={{sizeOf "inner" 0}}>
+            <div class="rz-pane">editor</div>
+          </inner.Panel>
+          <inner.Handle aria-label="Resize output" />
+          <inner.Panel @defaultSize={{sizeOf "inner" 1}} @minSize={{10}}>
+            <div class="rz-pane">output</div>
+          </inner.Panel>
+        </Resizable>
+      </r.Panel>
+    </Resizable>
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .rz-persisted {
+      height: 220px;
+      border: 1px solid gray;
+    }
+    .rz-persisted .rz-pane {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+    }
+    .rz-persisted .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .rz-persisted .ember-primitives__resizable__handle:hover,
+    .rz-persisted .ember-primitives__resizable__handle:focus-visible,
+    .rz-persisted .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
+</template>
+```
+
+</div>
 
 ## Accessibility
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -576,6 +576,160 @@ const Tree = <template>
 
 </div>
 
+## Controlled layout
+
+A layout like [limber](https://limber.glimdown.com)'s REPL: an editor and its output, with controls layered on top of the editor for minimizing, maximizing, and rotating. Maximized and minimized are just different templates -- the `<Resizable>` only renders in the default mode, and remembers its sizes (via `@onLayoutChange` / `@size`) across mode changes.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { cell } from 'ember-resources';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
+
+const mode = cell('default'); // 'default' | 'maximized' | 'minimized'
+const orientation = cell('horizontal');
+
+// remembered across mode changes (this could also be localStorage)
+let sizes = [40, 60];
+const rememberSizes = (next) => (sizes = next);
+const sizeAt = (index) => sizes[index];
+
+const toggleMaximize = () => mode.set(mode.current === 'maximized' ? 'default' : 'maximized');
+const toggleMinimize = () => mode.set(mode.current === 'minimized' ? 'default' : 'minimized');
+const rotate = () =>
+  orientation.set(orientation.current === 'horizontal' ? 'vertical' : 'horizontal');
+
+const Controls = <template>
+  <div class="limber-controls">
+    <button type="button" {{on "click" rotate}}>
+      rotate
+    </button>
+    <button type="button" {{on "click" toggleMinimize}}>
+      {{if (eq mode.current "minimized") "restore" "min"}}
+    </button>
+    <button type="button" {{on "click" toggleMaximize}}>
+      {{if (eq mode.current "maximized") "restore" "max"}}
+    </button>
+  </div>
+</template>;
+
+const Editor = <template>
+  <div class="limber-editor">
+    <Controls />
+    <pre>&lt;template&gt;
+  Hello, &#123;&#123;@name&#125;&#125;!
+&lt;/template&gt;</pre>
+  </div>
+</template>;
+
+const Output = <template>
+  <div class="limber-output">Hello, world!</div>
+</template>;
+
+<template>
+  <div class="limber">
+    {{#if (eq mode.current "maximized")}}
+      <Editor />
+    {{else if (eq mode.current "minimized")}}
+      <div class="limber-minimized" data-orientation={{orientation.current}}>
+        <div class="limber-sliver"><Controls /></div>
+        <Output />
+      </div>
+    {{else}}
+      <Resizable @orientation={{orientation.current}} @onLayoutChange={{rememberSizes}}>
+        <Panel @size={{sizeAt 0}} @minSize={{10}}>
+          <Editor />
+        </Panel>
+        <Handle aria-label="Resize editor" />
+        <Panel @size={{sizeAt 1}} @minSize={{10}}>
+          <Output />
+        </Panel>
+      </Resizable>
+    {{/if}}
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .limber {
+      height: 240px;
+      border: 1px solid gray;
+    }
+    .limber-editor {
+      position: relative;
+      height: 100%;
+      background: #1e1e2e;
+      color: #cdd6f4;
+    }
+    .limber-editor pre {
+      margin: 0;
+      padding: 1rem;
+      font-size: 0.8125rem;
+    }
+    .limber-controls {
+      position: absolute;
+      top: 0.375rem;
+      right: 0.375rem;
+      display: flex;
+      gap: 0.25rem;
+      z-index: 1;
+    }
+    .limber-controls button {
+      font-family: monospace;
+      font-size: 0.6875rem;
+      padding: 0.125rem 0.375rem;
+      background: #313244;
+      color: #cdd6f4;
+      border: 1px solid #45475a;
+      cursor: pointer;
+    }
+    .limber-controls button:hover {
+      border-color: #89b4fa;
+    }
+    .limber-output {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+    }
+    .limber-minimized {
+      display: flex;
+      height: 100%;
+    }
+    .limber-minimized[data-orientation='horizontal'] {
+      flex-direction: row;
+    }
+    .limber-minimized[data-orientation='vertical'] {
+      flex-direction: column;
+    }
+    .limber-sliver {
+      position: relative;
+      flex: 0 0 auto;
+      background: #1e1e2e;
+    }
+    .limber-minimized[data-orientation='horizontal'] .limber-sliver {
+      width: 11rem;
+    }
+    .limber-minimized[data-orientation='vertical'] .limber-sliver {
+      height: 2rem;
+    }
+    .limber-minimized .limber-output {
+      flex: 1;
+    }
+    .limber .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .limber .ember-primitives__resizable__handle:hover,
+    .limber .ember-primitives__resizable__handle:focus-visible,
+    .limber .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
+</template>
+```
+
+</div>
+
 ## Persisting the layout
 
 `@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@size` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -60,7 +60,7 @@ import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable'
 ## i3: a tree-based window manager
 
 Because groups nest, a whole tiling window manager layout is just a tree of `<Resizable>`s.
-Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab</kbd> to the borders to resize.
+Click a window to focus it, then split it, flip its container's layout, or kill it, i3wm style. Drag or <kbd>Tab</kbd> to the borders to resize.
 
 <div class="featured-demo auto-height">
 
@@ -85,7 +85,7 @@ class AppWindow {
 }
 
 class Split {
-  orientation;
+  @tracked orientation;
   children;
 
   constructor(orientation, children) {
@@ -144,6 +144,16 @@ class WindowManager {
     this.focused = win;
   };
 
+  toggleLayout = () => {
+    const { focused, root } = this;
+    const parent = focused ? findParent(root, focused) : root;
+
+    if (!parent) return;
+
+    // i3's $mod+e: flip the container's split direction; panels keep their sizes
+    parent.orientation = parent.orientation === 'horizontal' ? 'vertical' : 'horizontal';
+  };
+
   kill = () => {
     const { focused, root } = this;
 
@@ -198,6 +208,7 @@ const Tree = <template>
     <div class="i3-bar">
       <button type="button" {{on "click" (fn wm.split "horizontal")}}>$mod+Enter (split h)</button>
       <button type="button" {{on "click" (fn wm.split "vertical")}}>$mod+v (split v)</button>
+      <button type="button" {{on "click" wm.toggleLayout}}>$mod+e (toggle layout)</button>
       <button type="button" {{on "click" wm.kill}}>$mod+Shift+q (kill)</button>
       <span class="i3-status">1: {{if wm.focused wm.focused.title "(empty)"}}</span>
     </div>
@@ -405,18 +416,102 @@ import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable'
 
 </div>
 
-## Persisting the layout
+## Adding, removing, and splitting panels
 
-`@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@size` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
-
-With nested groups, each group persists its own sizes under its own key. Resize the panels below, then reload the page -- the layout is remembered.
+Panels are discovered from the DOM, so managing a layout is just managing what you render: `{{#each}}` over your own state, add or remove entries, nest a `<Resizable>` for a split. New panels take an equal share (existing panels scale down to make room), removed panels give their space back, and the whole group can be rotated at any time.
 
 <div class="featured-demo auto-height">
 
 ```gjs live preview no-shadow
+import { cell } from 'ember-resources';
+import { trackedArray } from '@ember/reactive/collections';
+import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
+
+let nextId = 1;
+const entries = trackedArray([{ id: nextId++, split: false }]);
+const orientation = cell('horizontal');
+const crossOrientation = () => (orientation.current === 'horizontal' ? 'vertical' : 'horizontal');
+
+const addPanel = () => entries.push({ id: nextId++, split: false });
+const addSplit = () => entries.push({ id: nextId++, split: true });
+const removeLast = () => entries.length > 1 && entries.pop();
+const rotate = () => orientation.set(crossOrientation());
+
+<template>
+  <div class="rz-dynamic-bar">
+    <button type="button" {{on "click" addPanel}}>Add panel</button>
+    <button type="button" {{on "click" addSplit}}>Add split</button>
+    <button type="button" {{on "click" removeLast}}>Remove last</button>
+    <button type="button" {{on "click" rotate}}>Rotate ({{orientation.current}})</button>
+  </div>
+
+  <div class="rz-dynamic">
+    <Resizable @orientation={{orientation.current}}>
+      {{#each entries key="id" as |entry index|}}
+        {{#if index}}
+          <Handle aria-label="Resize" />
+        {{/if}}
+        <Panel @minSize={{5}}>
+          {{#if entry.split}}
+            <Resizable @orientation={{(crossOrientation)}}>
+              <Panel><div class="rz-pane">{{entry.id}}a</div></Panel>
+              <Handle aria-label="Resize split" />
+              <Panel><div class="rz-pane">{{entry.id}}b</div></Panel>
+            </Resizable>
+          {{else}}
+            <div class="rz-pane">{{entry.id}}</div>
+          {{/if}}
+        </Panel>
+      {{/each}}
+    </Resizable>
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .rz-dynamic-bar {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .rz-dynamic {
+      height: 220px;
+      margin-top: 0.5rem;
+      border: 1px solid gray;
+    }
+    .rz-dynamic .rz-pane {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+    }
+    .rz-dynamic .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .rz-dynamic .ember-primitives__resizable__handle:hover,
+    .rz-dynamic .ember-primitives__resizable__handle:focus-visible,
+    .rz-dynamic .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
+</template>
+```
+
+</div>
+
+## Persisting the layout
+
+`@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@size` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
+
+With nested groups, each group persists its own sizes under its own key. Resize the panels below, then unmount and remount the whole layout (or reload the page) -- it comes back exactly as you left it.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { cell } from 'ember-resources';
 import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
 const KEY = 'docs:resizable:persisted-demo';
+const isShown = cell(true);
 
 function load() {
   try {
@@ -436,8 +531,13 @@ const persist = (group) => (sizes) => {
 const sizeOf = (group, index) => saved[group]?.[index];
 
 <template>
+  <button type="button" {{on "click" isShown.toggle}}>
+    {{if isShown.current "Unmount" "Remount"}} the layout
+  </button>
+
   <div class="rz-persisted">
-    <Resizable @onLayoutChange={{persist "outer"}}>
+    {{#if isShown.current}}
+      <Resizable @onLayoutChange={{persist "outer"}}>
       <Panel @size={{sizeOf "outer" 0}} @minSize={{15}}>
         <div class="rz-pane">files</div>
       </Panel>
@@ -453,7 +553,10 @@ const sizeOf = (group, index) => saved[group]?.[index];
           </Panel>
         </Resizable>
       </Panel>
-    </Resizable>
+      </Resizable>
+    {{else}}
+      <div class="rz-pane">(unmounted)</div>
+    {{/if}}
   </div>
   <style>
     /* styles for the demo, not required */

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -66,7 +66,7 @@ Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab<
 
 ```gjs live preview no-shadow
 import { tracked } from '@glimmer/tracking';
-import { TrackedArray } from 'tracked-built-ins';
+import { trackedArray } from '@ember/reactive/collections';
 import { Resizable } from 'ember-primitives';
 
 const PROGRAMS = ['URxvt', 'firefox', 'emacs', 'htop', 'ncmpcpp', 'ranger', 'weechat', 'neomutt'];
@@ -90,7 +90,7 @@ class Split {
 
   constructor(orientation, children) {
     this.orientation = orientation;
-    this.children = new TrackedArray(children);
+    this.children = trackedArray(children);
   }
 }
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -737,13 +737,13 @@ const Output = <template>
     .limber-minimized[data-orientation='horizontal'] .limber-sliver {
       width: 2rem;
     }
-    /* in the narrow sliver, the buttons rotate 90° to fit */
+    /* in the narrow sliver, the whole button row rotates 90° to fit */
     .limber-minimized[data-orientation='horizontal'] .limber-controls {
-      position: static;
-      flex-direction: column;
-      align-items: center;
-      padding: 0.375rem 0.25rem;
-      writing-mode: vertical-rl;
+      top: 0.375rem;
+      right: auto;
+      left: 100%;
+      transform: rotate(90deg);
+      transform-origin: top left;
     }
     .limber-minimized[data-orientation='vertical'] .limber-sliver {
       height: 2rem;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -418,69 +418,147 @@ import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable'
 
 ## Adding, removing, and splitting panels
 
-Panels are discovered from the DOM, so managing a layout is just managing what you render: `{{#each}}` over your own state, add or remove entries, nest a `<Resizable>` for a split. New panels take an equal share (existing panels scale down to make room), removed panels give their space back, and the whole group can be rotated at any time.
+Panels are discovered from the DOM, so managing a layout is just managing what you render: `{{#each}}` over your own state, add or remove entries, nest a `<Resizable>` for a split.
+
+Click a panel to focus its `<Resizable>` (highlighted) -- the buttons apply to the focused group. New panels take an equal share (existing panels scale down to make room), and removed panels give their space back.
 
 <div class="featured-demo auto-height">
 
 ```gjs live preview no-shadow
+import { tracked } from '@glimmer/tracking';
 import { cell } from 'ember-resources';
 import { trackedArray } from '@ember/reactive/collections';
 import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
 
 let nextId = 1;
-const entries = trackedArray([{ id: nextId++, split: false }]);
-const orientation = cell('horizontal');
-const crossOrientation = () => (orientation.current === 'horizontal' ? 'vertical' : 'horizontal');
 
-const addPanel = () => entries.push({ id: nextId++, split: false });
-const addSplit = () => entries.push({ id: nextId++, split: true });
-const removeLast = () => entries.length > 1 && entries.pop();
-const rotate = () => orientation.set(crossOrientation());
+class PanelNode {
+  id = nextId++;
+}
+
+class GroupNode {
+  id = nextId++;
+  @tracked orientation;
+  children;
+
+  constructor(orientation, children) {
+    this.orientation = orientation;
+    this.children = trackedArray(children);
+  }
+}
+
+const isGroup = (node) => node instanceof GroupNode;
+const cross = (orientation) => (orientation === 'horizontal' ? 'vertical' : 'horizontal');
+
+const root = new GroupNode('horizontal', [new PanelNode(), new PanelNode()]);
+const focused = cell(root);
+
+const focus = (group) => focused.set(group);
+
+function findParent(node, target) {
+  if (!isGroup(node)) return null;
+
+  for (const child of node.children) {
+    if (child === target) return node;
+
+    const found = findParent(child, target);
+
+    if (found) return found;
+  }
+
+  return null;
+}
+
+const addPanel = () => focused.current.children.push(new PanelNode());
+
+const addSplit = () => {
+  const group = new GroupNode(cross(focused.current.orientation), [
+    new PanelNode(),
+    new PanelNode(),
+  ]);
+
+  focused.current.children.push(group);
+  focused.set(group);
+};
+
+const removeLast = () => {
+  const group = focused.current;
+
+  group.children.pop();
+
+  // an emptied group (other than the root) disappears entirely
+  if (group !== root && group.children.length === 0) {
+    const parent = findParent(root, group);
+
+    parent.children.splice(parent.children.indexOf(group), 1);
+    focused.set(parent);
+  }
+};
+
+const rotate = () => (focused.current.orientation = cross(focused.current.orientation));
+
+const Tree = <template>
+  <Resizable
+    @orientation={{@node.orientation}}
+    class={{if (eq focused.current @node) "is-focused"}}
+  >
+    {{#each @node.children key="id" as |child index|}}
+      {{#if index}}
+        <Handle aria-label="Resize" />
+      {{/if}}
+      <Panel @minSize={{10}}>
+        {{#if (isGroup child)}}
+          <Tree @node={{child}} />
+        {{else}}
+          <button type="button" class="rz-pane" {{on "click" (fn focus @node)}}>
+            {{child.id}}
+          </button>
+        {{/if}}
+      </Panel>
+    {{/each}}
+  </Resizable>
+</template>;
 
 <template>
   <div class="rz-dynamic-bar">
     <button type="button" {{on "click" addPanel}}>Add panel</button>
     <button type="button" {{on "click" addSplit}}>Add split</button>
     <button type="button" {{on "click" removeLast}}>Remove last</button>
-    <button type="button" {{on "click" rotate}}>Rotate ({{orientation.current}})</button>
+    <button type="button" {{on "click" rotate}}>Rotate</button>
+    <span>focused: group {{focused.current.id}} ({{focused.current.orientation}})</span>
   </div>
 
   <div class="rz-dynamic">
-    <Resizable @orientation={{orientation.current}}>
-      {{#each entries key="id" as |entry index|}}
-        {{#if index}}
-          <Handle aria-label="Resize" />
-        {{/if}}
-        <Panel @minSize={{5}}>
-          {{#if entry.split}}
-            <Resizable @orientation={{(crossOrientation)}}>
-              <Panel><div class="rz-pane">{{entry.id}}a</div></Panel>
-              <Handle aria-label="Resize split" />
-              <Panel><div class="rz-pane">{{entry.id}}b</div></Panel>
-            </Resizable>
-          {{else}}
-            <div class="rz-pane">{{entry.id}}</div>
-          {{/if}}
-        </Panel>
-      {{/each}}
-    </Resizable>
+    <Tree @node={{root}} />
   </div>
   <style>
     /* styles for the demo, not required */
     .rz-dynamic-bar {
       display: flex;
       gap: 0.5rem;
+      align-items: center;
     }
     .rz-dynamic {
       height: 220px;
       margin-top: 0.5rem;
       border: 1px solid gray;
     }
+    .rz-dynamic .ember-primitives__resizable.is-focused {
+      outline: 2px solid dodgerblue;
+      outline-offset: -2px;
+    }
     .rz-dynamic .rz-pane {
       display: grid;
       place-items: center;
+      width: 100%;
       height: 100%;
+      padding: 0;
+      border: none;
+      background: transparent;
+      color: inherit;
       font-family: monospace;
+      font-size: 1rem;
+      cursor: pointer;
     }
     .rz-dynamic .ember-primitives__resizable__handle {
       background: gray;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -420,7 +420,7 @@ import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable'
 
 Panels are discovered from the DOM, so managing a layout is just managing what you render: `{{#each}}` over your own state, add or remove entries, nest a `<Resizable>` for a split.
 
-Click a panel to focus its `<Resizable>` (highlighted) -- the buttons apply to the focused group. New panels take an equal share (existing panels scale down to make room), and removed panels give their space back.
+Click a panel to focus it (highlighted). **Add panel** inserts a sibling after the focused panel, **Split** wraps the focused panel in a new cross-oriented group (so further additions land *inside* the split), **Rotate** flips the focused panel's group, and **Remove** deletes the focused panel -- groups left with a single child dissolve.
 
 <div class="featured-demo auto-height">
 
@@ -437,7 +437,6 @@ class PanelNode {
 }
 
 class GroupNode {
-  id = nextId++;
   @tracked orientation;
   children;
 
@@ -451,9 +450,8 @@ const isGroup = (node) => node instanceof GroupNode;
 const cross = (orientation) => (orientation === 'horizontal' ? 'vertical' : 'horizontal');
 
 const root = new GroupNode('horizontal', [new PanelNode(), new PanelNode()]);
-const focused = cell(root);
-
-const focus = (group) => focused.set(group);
+const focused = cell(root.children[0]);
+const focus = (panel) => focused.set(panel);
 
 function findParent(node, target) {
   if (!isGroup(node)) return null;
@@ -469,39 +467,59 @@ function findParent(node, target) {
   return null;
 }
 
-const addPanel = () => focused.current.children.push(new PanelNode());
+function firstPanel(node) {
+  if (!isGroup(node)) return node;
 
-const addSplit = () => {
-  const group = new GroupNode(cross(focused.current.orientation), [
-    new PanelNode(),
-    new PanelNode(),
-  ]);
+  return node.children.length ? firstPanel(node.children[0]) : null;
+}
 
-  focused.current.children.push(group);
-  focused.set(group);
+const addPanel = () => {
+  const parent = findParent(root, focused.current) ?? root;
+  const panel = new PanelNode();
+
+  parent.children.splice(parent.children.indexOf(focused.current) + 1, 0, panel);
+  focused.set(panel);
 };
 
-const removeLast = () => {
-  const group = focused.current;
+const split = () => {
+  const target = focused.current;
+  const parent = findParent(root, target);
 
-  group.children.pop();
+  if (!parent) return;
 
-  // an emptied group (other than the root) disappears entirely
-  if (group !== root && group.children.length === 0) {
-    const parent = findParent(root, group);
+  const panel = new PanelNode();
+  const group = new GroupNode(cross(parent.orientation), [target, panel]);
 
-    parent.children.splice(parent.children.indexOf(group), 1);
-    focused.set(parent);
+  parent.children.splice(parent.children.indexOf(target), 1, group);
+  focused.set(panel);
+};
+
+const removePanel = () => {
+  const target = focused.current;
+  const parent = findParent(root, target);
+
+  if (!parent) return;
+
+  parent.children.splice(parent.children.indexOf(target), 1);
+
+  // groups left with a single child dissolve into their parent
+  if (parent !== root && parent.children.length === 1) {
+    const grandparent = findParent(root, parent);
+
+    grandparent.children.splice(grandparent.children.indexOf(parent), 1, parent.children[0]);
   }
+
+  focused.set(firstPanel(parent.children.length ? parent : root));
 };
 
-const rotate = () => (focused.current.orientation = cross(focused.current.orientation));
+const rotate = () => {
+  const parent = findParent(root, focused.current);
+
+  if (parent) parent.orientation = cross(parent.orientation);
+};
 
 const Tree = <template>
-  <Resizable
-    @orientation={{@node.orientation}}
-    class={{if (eq focused.current @node) "is-focused"}}
-  >
+  <Resizable @orientation={{@node.orientation}}>
     {{#each @node.children key="id" as |child index|}}
       {{#if index}}
         <Handle aria-label="Resize" />
@@ -510,7 +528,11 @@ const Tree = <template>
         {{#if (isGroup child)}}
           <Tree @node={{child}} />
         {{else}}
-          <button type="button" class="rz-pane" {{on "click" (fn focus @node)}}>
+          <button
+            type="button"
+            class="rz-pane {{if (eq focused.current child) 'is-focused'}}"
+            {{on "click" (fn focus child)}}
+          >
             {{child.id}}
           </button>
         {{/if}}
@@ -522,10 +544,17 @@ const Tree = <template>
 <template>
   <div class="rz-dynamic-bar">
     <button type="button" {{on "click" addPanel}}>Add panel</button>
-    <button type="button" {{on "click" addSplit}}>Add split</button>
-    <button type="button" {{on "click" removeLast}}>Remove last</button>
+    <button type="button" {{on "click" split}}>Split</button>
+    <button type="button" {{on "click" removePanel}}>Remove</button>
     <button type="button" {{on "click" rotate}}>Rotate</button>
-    <span>focused: group {{focused.current.id}} ({{focused.current.orientation}})</span>
+    <span>
+      {{#if focused.current}}
+        focused: panel
+        {{focused.current.id}}
+      {{else}}
+        focused: (none)
+      {{/if}}
+    </span>
   </div>
 
   <div class="rz-dynamic">
@@ -543,10 +572,6 @@ const Tree = <template>
       margin-top: 0.5rem;
       border: 1px solid gray;
     }
-    .rz-dynamic .ember-primitives__resizable.is-focused {
-      outline: 2px solid dodgerblue;
-      outline-offset: -2px;
-    }
     .rz-dynamic .rz-pane {
       display: grid;
       place-items: center;
@@ -559,6 +584,10 @@ const Tree = <template>
       font-family: monospace;
       font-size: 1rem;
       cursor: pointer;
+    }
+    .rz-dynamic .rz-pane.is-focused {
+      outline: 2px solid dodgerblue;
+      outline-offset: -2px;
     }
     .rz-dynamic .ember-primitives__resizable__handle {
       background: gray;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -706,7 +706,15 @@ const Output = <template>
       background: #1e1e2e;
     }
     .limber-minimized[data-orientation='horizontal'] .limber-sliver {
-      width: 11rem;
+      width: 2rem;
+    }
+    /* in the narrow sliver, the buttons rotate 90° to fit */
+    .limber-minimized[data-orientation='horizontal'] .limber-controls {
+      position: static;
+      flex-direction: column;
+      align-items: center;
+      padding: 0.375rem 0.25rem;
+      writing-mode: vertical-rl;
     }
     .limber-minimized[data-orientation='vertical'] .limber-sliver {
       height: 2rem;

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -1,0 +1,392 @@
+# Resizable
+
+Panels with draggable (and keyboard-operable) dividers between them.
+
+Each `<Resizable>` is a flat row (or column) of panels -- but a panel may contain another `<Resizable>`, so layouts compose into arbitrary trees, the same way tiling window managers (i3, sway, tmux) model their screen.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { Resizable } from 'ember-primitives';
+
+<template>
+  <div class="rz-demo">
+    <Resizable as |r|>
+      <r.Panel @minSize={{15}} @defaultSize={{25}}>
+        <div class="rz-pane">sidebar</div>
+      </r.Panel>
+      <r.Handle aria-label="Resize sidebar" />
+      <r.Panel>
+        <Resizable @orientation="vertical" as |inner|>
+          <inner.Panel>
+            <div class="rz-pane">editor</div>
+          </inner.Panel>
+          <inner.Handle aria-label="Resize terminal" />
+          <inner.Panel @minSize={{10}} @defaultSize={{30}} @collapsible={{true}}>
+            <div class="rz-pane">terminal</div>
+          </inner.Panel>
+        </Resizable>
+      </r.Panel>
+    </Resizable>
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .rz-demo {
+      height: 240px;
+      border: 1px solid gray;
+    }
+    .rz-demo .rz-pane {
+      display: grid;
+      place-items: center;
+      height: 100%;
+      font-family: monospace;
+    }
+    .rz-demo .ember-primitives__resizable__handle {
+      background: gray;
+      opacity: 0.4;
+    }
+    .rz-demo .ember-primitives__resizable__handle:hover,
+    .rz-demo .ember-primitives__resizable__handle:focus-visible,
+    .rz-demo .ember-primitives__resizable__handle[data-resizing] {
+      opacity: 1;
+      background: dodgerblue;
+    }
+  </style>
+</template>
+```
+
+</div>
+
+## i3, but it's a demo
+
+Because groups nest, a whole tiling window manager layout is just a tree of `<Resizable>`s.
+Click a window to focus it, then split or kill it, i3wm style. Drag or <kbd>Tab</kbd> to the borders to resize.
+
+<div class="featured-demo auto-height">
+
+```gjs live preview no-shadow
+import { tracked } from '@glimmer/tracking';
+import { fn } from '@ember/helper';
+import { on } from '@ember/modifier';
+import { TrackedArray } from 'tracked-built-ins';
+import { Resizable } from 'ember-primitives';
+
+const PROGRAMS = ['URxvt', 'firefox', 'emacs', 'htop', 'ncmpcpp', 'ranger', 'weechat', 'neomutt'];
+const PROMPTS = ['~ $ ', '~/dev $ make', '*scratch*', 'MEM 42%', '♫ paused', '~/…/photos', '#ember', 'INBOX (3)'];
+let launches = 0;
+
+class AppWindow {
+  @tracked title;
+  content;
+
+  constructor() {
+    this.title = PROGRAMS[launches % PROGRAMS.length];
+    this.content = PROMPTS[launches % PROMPTS.length];
+    launches++;
+  }
+}
+
+class Split {
+  orientation;
+  children;
+
+  constructor(orientation, children) {
+    this.orientation = orientation;
+    this.children = new TrackedArray(children);
+  }
+}
+
+const isSplit = (node) => node instanceof Split;
+const eq = (a, b) => a === b;
+const gt = (a, b) => a > b;
+
+function findParent(node, target) {
+  if (!isSplit(node)) return null;
+
+  for (const child of node.children) {
+    if (child === target) return node;
+
+    const found = findParent(child, target);
+
+    if (found) return found;
+  }
+
+  return null;
+}
+
+function firstWindow(node) {
+  if (!isSplit(node)) return node;
+
+  return node.children.length ? firstWindow(node.children[0]) : null;
+}
+
+class WindowManager {
+  root = new Split('horizontal', [new AppWindow()]);
+  @tracked focused = firstWindow(this.root);
+
+  focus = (node) => (this.focused = node);
+
+  split = (orientation) => {
+    const win = new AppWindow();
+    const { focused, root } = this;
+    const parent = focused ? findParent(root, focused) : root;
+
+    if (!parent) return;
+
+    if (!focused) {
+      root.children.push(win);
+    } else if (parent.orientation === orientation) {
+      // i3: splitting along the container's own axis just adds a sibling
+      parent.children.splice(parent.children.indexOf(focused) + 1, 0, win);
+    } else {
+      // otherwise the focused window is wrapped in a new (nested) container
+      const wrapped = new Split(orientation, [focused, win]);
+
+      parent.children.splice(parent.children.indexOf(focused), 1, wrapped);
+    }
+
+    this.focused = win;
+  };
+
+  kill = () => {
+    const { focused, root } = this;
+
+    if (!focused) return;
+
+    const parent = findParent(root, focused);
+
+    if (!parent) return;
+
+    parent.children.splice(parent.children.indexOf(focused), 1);
+
+    // containers with a single child dissolve into their parent
+    if (parent !== root && parent.children.length === 1) {
+      const grandparent = findParent(root, parent);
+      const only = parent.children[0];
+
+      grandparent.children.splice(grandparent.children.indexOf(parent), 1, only);
+    }
+
+    this.focused = firstWindow(parent.children.length ? parent : root);
+  };
+}
+
+const wm = new WindowManager();
+
+const Tree = <template>
+  {{#if (isSplit @node)}}
+    <Resizable @orientation={{@node.orientation}} as |r|>
+      {{#each @node.children as |child index|}}
+        {{#if (gt index 0)}}
+          <r.Handle aria-label="Resize window" />
+        {{/if}}
+        <r.Panel @minSize={{5}}>
+          <Tree @node={{child}} />
+        </r.Panel>
+      {{/each}}
+    </Resizable>
+  {{else}}
+    <button
+      type="button"
+      class="i3-window {{if (eq wm.focused @node) 'is-focused'}}"
+      {{on "click" (fn wm.focus @node)}}
+    >
+      <span class="i3-title">{{@node.title}}</span>
+      <span class="i3-body">{{@node.content}}</span>
+    </button>
+  {{/if}}
+</template>;
+
+<template>
+  <div class="i3">
+    <div class="i3-bar">
+      <button type="button" {{on "click" (fn wm.split "horizontal")}}>$mod+Enter (split h)</button>
+      <button type="button" {{on "click" (fn wm.split "vertical")}}>$mod+v (split v)</button>
+      <button type="button" {{on "click" wm.kill}}>$mod+Shift+q (kill)</button>
+      <span class="i3-status">1: {{if wm.focused wm.focused.title "(empty)"}}</span>
+    </div>
+    <div class="i3-workspace">
+      <Tree @node={{wm.root}} />
+    </div>
+  </div>
+  <style>
+    /* styles for the demo, not required */
+    .i3 {
+      background: #000;
+      border: 1px solid #333;
+      font-family: monospace;
+    }
+    .i3-bar {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      padding: 0.25rem 0.5rem;
+      background: #111;
+      border-bottom: 1px solid #333;
+    }
+    .i3-bar button {
+      font: inherit;
+      font-size: 0.75rem;
+      color: #ccc;
+      background: #222;
+      border: 1px solid #444;
+      padding: 0.125rem 0.5rem;
+      cursor: pointer;
+    }
+    .i3-bar button:hover {
+      border-color: #4c7899;
+    }
+    .i3-status {
+      margin-left: auto;
+      color: #888;
+      font-size: 0.75rem;
+    }
+    .i3-workspace {
+      height: 320px;
+      padding: 3px;
+    }
+    .i3-window {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      padding: 0;
+      text-align: left;
+      font: inherit;
+      background: #0c0c0c;
+      border: 2px solid #333;
+      cursor: pointer;
+    }
+    .i3-window.is-focused {
+      border-color: #285577;
+    }
+    .i3-title {
+      display: block;
+      padding: 2px 6px;
+      font-size: 0.75rem;
+      background: #333;
+      color: #888;
+    }
+    .i3-window.is-focused .i3-title {
+      background: #285577;
+      color: #fff;
+    }
+    .i3-body {
+      flex: 1;
+      padding: 6px;
+      font-size: 0.8125rem;
+      color: #6a9955;
+    }
+    .i3 .ember-primitives__resizable__handle {
+      background: #1a1a1a;
+    }
+    .i3 .ember-primitives__resizable[data-orientation='horizontal']
+      > .ember-primitives__resizable__handle {
+      width: 5px;
+    }
+    .i3 .ember-primitives__resizable[data-orientation='vertical']
+      > .ember-primitives__resizable__handle {
+      height: 5px;
+    }
+    .i3 .ember-primitives__resizable__handle:hover,
+    .i3 .ember-primitives__resizable__handle:focus-visible,
+    .i3 .ember-primitives__resizable__handle[data-resizing] {
+      background: #4c7899;
+      outline: none;
+    }
+  </style>
+</template>
+```
+
+</div>
+
+## Install
+
+```bash
+pnpm add ember-primitives
+```
+
+```js
+import { Resizable } from 'ember-primitives';
+// or
+import { Resizable } from 'ember-primitives/components/resizable';
+```
+
+## Anatomy
+
+```gjs
+import { Resizable } from 'ember-primitives';
+
+<template>
+  <Resizable @orientation="horizontal" as |r|>
+    <r.Panel>…</r.Panel>
+    <r.Handle aria-label="Resize" />
+    <r.Panel>
+      {{! panels may contain another <Resizable> }}
+    </r.Panel>
+  </Resizable>
+</template>
+```
+
+A `Handle` resizes the two panels on either side of it. Sizes are percentages of the group's space, applied via `flex-grow` -- the component ships only the structural CSS (flex layout, cursors, `touch-action`); all appearance (handle color, width, hover/focus styles) is up to you.
+
+Dragging uses pointer capture, so resizing keeps working when the pointer passes over iframes -- no overlay element needed.
+
+## Persisting the layout
+
+`@onLayoutChange` is called with the panels' sizes (percentages, in document order) whenever the layout changes, and `@defaultSize` sets the initial size -- together they make persistence straightforward (localStorage, query params, etc.).
+
+## Accessibility
+
+The handle follows the [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern: it is a focusable `role="separator"` with `aria-valuenow/min/max` describing the panel before it (also referenced via `aria-controls`).
+
+Give each handle an accessible name (e.g. `aria-label="Resize sidebar"`).
+
+### Keyboard Interactions
+
+| key | description |
+| :---: | :----------- |
+| <kbd>ArrowLeft</kbd> / <kbd>ArrowRight</kbd> | Move the boundary of a horizontal group (1%, or 10% with <kbd>Shift</kbd>) |
+| <kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd> | Move the boundary of a vertical group (1%, or 10% with <kbd>Shift</kbd>) |
+| <kbd>Home</kbd> | Shrink the preceding panel to its `@minSize` |
+| <kbd>End</kbd> | Grow the preceding panel to its `@maxSize` |
+| <kbd>Enter</kbd> | Collapse / restore the preceding panel (when it is `@collapsible`) |
+
+## API Reference
+
+```gjs live no-shadow
+import { ComponentSignature } from 'kolay';
+
+<template>
+  <ComponentSignature
+    @package="ember-primitives"
+    @module="declarations/components/resizable"
+    @name="Signature" />
+</template>
+```
+
+### Panel
+
+```gjs live no-shadow
+import { ComponentSignature } from 'kolay';
+
+<template>
+  <ComponentSignature
+    @package="ember-primitives"
+    @module="declarations/components/resizable"
+    @name="PanelSignature" />
+</template>
+```
+
+### Handle
+
+```gjs live no-shadow
+import { ComponentSignature } from 'kolay';
+
+<template>
+  <ComponentSignature
+    @package="ember-primitives"
+    @module="declarations/components/resizable"
+    @name="HandleSignature" />
+</template>
+```

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -75,16 +75,10 @@ let launches = 0;
 
 class AppWindow {
   @tracked title;
-  /**
-   * Focus is a per-window flag (not a comparison against a shared
-   * `focused` value) so a focus change only invalidates the two
-   * windows involved -- every other window's class binding stays
-   * untouched, and observers see no writes on them.
-   */
-  @tracked isFocused = false;
   content;
 
   constructor() {
+    this.id = launches;
     this.title = PROGRAMS[launches % PROGRAMS.length];
     this.content = PROMPTS[launches % PROMPTS.length];
     launches++;
@@ -123,26 +117,63 @@ function firstWindow(node) {
   return node.children.length ? firstWindow(node.children[0]) : null;
 }
 
-class WindowManager {
-  root = new Split('horizontal', [new AppWindow()]);
-  @tracked focused = firstWindow(this.root);
+function windowById(node, id) {
+  if (!isSplit(node)) return node.id === id ? node : null;
 
-  constructor() {
-    if (this.focused) this.focused.isFocused = true;
+  for (const child of node.children) {
+    const found = windowById(child, id);
+
+    if (found) return found;
   }
 
-  focus = (node) => {
-    if (this.focused === node) return;
+  return null;
+}
 
-    if (this.focused) this.focused.isFocused = false;
-    if (node) node.isFocused = true;
+/**
+ * Focus lives in the DOM: the windows are buttons, so clicking one
+ * focuses it, the highlight is plain CSS `:focus`, and the toolbar
+ * reads document.activeElement to find its target. No focus state to
+ * keep in sync, and focusing a window writes nothing anywhere else.
+ */
+function focusedWindow(root) {
+  const element = document.activeElement?.closest?.('.i3-window');
 
-    this.focused = node;
+  return element ? windowById(root, Number(element.dataset.id)) : null;
+}
+
+// the new window's element exists after the next render
+function focusWindow(win) {
+  if (!win) return;
+
+  requestAnimationFrame(() => document.querySelector(`.i3-window[data-id="${win.id}"]`)?.focus());
+}
+
+// on the toolbar: keep focus on the window the button operates on
+const keepFocus = (event) => event.preventDefault();
+
+class WindowManager {
+  root = new Split('horizontal', [new AppWindow()]);
+
+  /**
+   * Mirrors document.activeElement for the status bar (activeElement
+   * itself is not reactive); everything else reads the DOM directly.
+   */
+  @tracked focused = null;
+
+  syncFocus = (event) => {
+    const element = event.type === 'focusout' ? event.relatedTarget : event.target;
+    const win = element?.closest?.('.i3-window');
+    const node = win ? windowById(this.root, Number(win.dataset.id)) : null;
+
+    // focusout fires mid-render when the focused element is removed
+    // (split, kill); the tracked write has to happen outside of it
+    queueMicrotask(() => (this.focused = node));
   };
 
   split = (orientation) => {
     const win = new AppWindow();
-    const { focused, root } = this;
+    const root = this.root;
+    const focused = focusedWindow(root);
     const parent = focused ? findParent(root, focused) : root;
 
     if (!parent) return;
@@ -159,11 +190,12 @@ class WindowManager {
       parent.children.splice(parent.children.indexOf(focused), 1, wrapped);
     }
 
-    this.focus(win);
+    focusWindow(win);
   };
 
   toggleLayout = () => {
-    const { focused, root } = this;
+    const root = this.root;
+    const focused = focusedWindow(root);
     const parent = focused ? findParent(root, focused) : root;
 
     if (!parent) return;
@@ -173,7 +205,8 @@ class WindowManager {
   };
 
   kill = () => {
-    const { focused, root } = this;
+    const root = this.root;
+    const focused = focusedWindow(root);
 
     if (!focused) return;
 
@@ -191,7 +224,7 @@ class WindowManager {
       grandparent.children.splice(grandparent.children.indexOf(parent), 1, only);
     }
 
-    this.focus(firstWindow(parent.children.length ? parent : root));
+    focusWindow(firstWindow(parent.children.length ? parent : root));
   };
 }
 
@@ -210,11 +243,7 @@ const Tree = <template>
       {{/each}}
     </Resizable>
   {{else}}
-    <button
-      type="button"
-      class="i3-window {{if @node.isFocused 'is-focused'}}"
-      {{on "click" (fn wm.focus @node)}}
-    >
+    <button type="button" class="i3-window" data-id="{{@node.id}}">
       <span class="i3-title">{{@node.title}}</span>
       <span class="i3-body">{{@node.content}}</span>
     </button>
@@ -224,13 +253,25 @@ const Tree = <template>
 <template>
   <div class="i3">
     <div class="i3-bar">
-      <button type="button" {{on "click" (fn wm.split "horizontal")}}>split h</button>
-      <button type="button" {{on "click" (fn wm.split "vertical")}}>split v</button>
-      <button type="button" {{on "click" wm.toggleLayout}}>toggle layout</button>
-      <button type="button" {{on "click" wm.kill}}>kill</button>
+      <button
+        type="button"
+        {{on "mousedown" keepFocus}}
+        {{on "click" (fn wm.split "horizontal")}}
+      >split h</button>
+      <button
+        type="button"
+        {{on "mousedown" keepFocus}}
+        {{on "click" (fn wm.split "vertical")}}
+      >split v</button>
+      <button
+        type="button"
+        {{on "mousedown" keepFocus}}
+        {{on "click" wm.toggleLayout}}
+      >toggle layout</button>
+      <button type="button" {{on "mousedown" keepFocus}} {{on "click" wm.kill}}>kill</button>
       <span class="i3-status">1: {{if wm.focused wm.focused.title "(empty)"}}</span>
     </div>
-    <div class="i3-workspace">
+    <div class="i3-workspace" {{on "focusin" wm.syncFocus}} {{on "focusout" wm.syncFocus}}>
       <Tree @node={{wm.root}} />
     </div>
   </div>
@@ -282,8 +323,9 @@ const Tree = <template>
       border: 2px solid #333;
       cursor: pointer;
     }
-    .i3-window.is-focused {
+    .i3-window:focus {
       border-color: #285577;
+      outline: none;
     }
     .i3-title {
       display: block;
@@ -292,7 +334,7 @@ const Tree = <template>
       background: #333;
       color: #888;
     }
-    .i3-window.is-focused .i3-title {
+    .i3-window:focus .i3-title {
       background: #285577;
       color: #fff;
     }
@@ -452,13 +494,6 @@ let nextId = 1;
 
 class PanelNode {
   id = nextId++;
-  /**
-   * A per-panel flag (rather than comparing against the shared
-   * `focused` value in the template) so a focus change only
-   * invalidates the two panels involved -- nothing is written to any
-   * other panel, not even a same-value `class`.
-   */
-  @tracked isFocused = false;
 }
 
 class GroupNode {
@@ -475,18 +510,53 @@ const isGroup = (node) => node instanceof GroupNode;
 const cross = (orientation) => (orientation === 'horizontal' ? 'vertical' : 'horizontal');
 
 const root = new GroupNode('horizontal', [new PanelNode(), new PanelNode()]);
-const focused = cell(root.children[0]);
 
-focused.current.isFocused = true;
+/**
+ * Focus lives in the DOM: the panels are buttons, so clicking one
+ * focuses it, the highlight is plain CSS `:focus`, and the toolbar
+ * reads document.activeElement to find its target. The cell only
+ * mirrors the focused panel's id for the status text (activeElement
+ * itself is not reactive).
+ */
+const focusedId = cell(null);
 
-const focus = (panel) => {
-  if (focused.current === panel) return;
+const syncFocus = (event) => {
+  const element = event.type === 'focusout' ? event.relatedTarget : event.target;
+  const pane = element?.closest?.('.rz-pane');
+  const id = pane ? Number(pane.dataset.id) : null;
 
-  if (focused.current) focused.current.isFocused = false;
-  if (panel) panel.isFocused = true;
-
-  focused.set(panel);
+  // focusout fires mid-render when the focused element is removed
+  // (split, remove); the tracked write has to happen outside of it
+  queueMicrotask(() => focusedId.set(id));
 };
+
+function panelById(node, id) {
+  if (!isGroup(node)) return node.id === id ? node : null;
+
+  for (const child of node.children) {
+    const found = panelById(child, id);
+
+    if (found) return found;
+  }
+
+  return null;
+}
+
+function focusedPanel() {
+  const pane = document.activeElement?.closest?.('.rz-pane');
+
+  return pane ? panelById(root, Number(pane.dataset.id)) : null;
+}
+
+// the new panel's element exists after the next render
+function focusPanel(panel) {
+  if (!panel) return;
+
+  requestAnimationFrame(() => document.querySelector(`.rz-pane[data-id="${panel.id}"]`)?.focus());
+}
+
+// on the toolbar: keep focus on the panel the button operates on
+const keepFocus = (event) => event.preventDefault();
 
 function findParent(node, target) {
   if (!isGroup(node)) return null;
@@ -509,16 +579,17 @@ function firstPanel(node) {
 }
 
 const addPanel = () => {
-  const parent = findParent(root, focused.current) ?? root;
+  const target = focusedPanel();
+  const parent = (target && findParent(root, target)) ?? root;
   const panel = new PanelNode();
 
-  parent.children.splice(parent.children.indexOf(focused.current) + 1, 0, panel);
-  focus(panel);
+  parent.children.splice(parent.children.indexOf(target) + 1, 0, panel);
+  focusPanel(panel);
 };
 
 const split = (orientation) => {
-  const target = focused.current;
-  const parent = findParent(root, target);
+  const target = focusedPanel();
+  const parent = target && findParent(root, target);
 
   if (!parent) return;
 
@@ -526,12 +597,12 @@ const split = (orientation) => {
   const group = new GroupNode(orientation, [target, panel]);
 
   parent.children.splice(parent.children.indexOf(target), 1, group);
-  focus(panel);
+  focusPanel(panel);
 };
 
 const removePanel = () => {
-  const target = focused.current;
-  const parent = findParent(root, target);
+  const target = focusedPanel();
+  const parent = target && findParent(root, target);
 
   if (!parent) return;
 
@@ -544,11 +615,12 @@ const removePanel = () => {
     grandparent.children.splice(grandparent.children.indexOf(parent), 1, parent.children[0]);
   }
 
-  focus(firstPanel(parent.children.length ? parent : root));
+  focusPanel(firstPanel(parent.children.length ? parent : root));
 };
 
 const rotate = () => {
-  const parent = findParent(root, focused.current);
+  const target = focusedPanel();
+  const parent = target && findParent(root, target);
 
   if (parent) parent.orientation = cross(parent.orientation);
 };
@@ -563,11 +635,7 @@ const Tree = <template>
         {{#if (isGroup child)}}
           <Tree @node={{child}} />
         {{else}}
-          <button
-            type="button"
-            class="rz-pane {{if child.isFocused 'is-focused'}}"
-            {{on "click" (fn focus child)}}
-          >
+          <button type="button" class="rz-pane" data-id="{{child.id}}">
             {{child.id}}
           </button>
         {{/if}}
@@ -578,22 +646,30 @@ const Tree = <template>
 
 <template>
   <div class="rz-dynamic-bar">
-    <button type="button" {{on "click" addPanel}}>Add panel</button>
-    <button type="button" {{on "click" (fn split "horizontal")}}>Split h</button>
-    <button type="button" {{on "click" (fn split "vertical")}}>Split v</button>
-    <button type="button" {{on "click" removePanel}}>Remove</button>
-    <button type="button" {{on "click" rotate}}>Rotate</button>
+    <button type="button" {{on "mousedown" keepFocus}} {{on "click" addPanel}}>Add panel</button>
+    <button
+      type="button"
+      {{on "mousedown" keepFocus}}
+      {{on "click" (fn split "horizontal")}}
+    >Split h</button>
+    <button
+      type="button"
+      {{on "mousedown" keepFocus}}
+      {{on "click" (fn split "vertical")}}
+    >Split v</button>
+    <button type="button" {{on "mousedown" keepFocus}} {{on "click" removePanel}}>Remove</button>
+    <button type="button" {{on "mousedown" keepFocus}} {{on "click" rotate}}>Rotate</button>
     <span>
-      {{#if focused.current}}
+      {{#if focusedId.current}}
         focused: panel
-        {{focused.current.id}}
+        {{focusedId.current}}
       {{else}}
         focused: (none)
       {{/if}}
     </span>
   </div>
 
-  <div class="rz-dynamic">
+  <div class="rz-dynamic" {{on "focusin" syncFocus}} {{on "focusout" syncFocus}}>
     <Tree @node={{root}} />
   </div>
   <style>
@@ -621,7 +697,7 @@ const Tree = <template>
       font-size: 1rem;
       cursor: pointer;
     }
-    .rz-dynamic .rz-pane.is-focused {
+    .rz-dynamic .rz-pane:focus {
       outline: 2px solid dodgerblue;
       outline-offset: -2px;
     }

--- a/docs-app/babel.config.mjs
+++ b/docs-app/babel.config.mjs
@@ -18,7 +18,7 @@ export default {
     [
       "babel-plugin-ember-template-compilation",
       {
-        compilerPath: "ember-source/dist/ember-template-compiler.js",
+        compilerPath: "ember-source/ember-template-compiler/index.js",
         enableLegacyModules: [
           "ember-cli-htmlbars",
           "ember-cli-htmlbars-inline-precompile",

--- a/docs-app/babel.config.mjs
+++ b/docs-app/babel.config.mjs
@@ -18,7 +18,6 @@ export default {
     [
       "babel-plugin-ember-template-compilation",
       {
-        compilerPath: "ember-source/ember-template-compiler/index.js",
         enableLegacyModules: [
           "ember-cli-htmlbars",
           "ember-cli-htmlbars-inline-precompile",

--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -96,7 +96,7 @@
     "ember-qunit": "^9.0.4",
     "ember-resources": "^7.0.7",
     "ember-scoped-css": "^2.0.4",
-    "ember-source": "^6.10.1",
+    "ember-source": "^7.1.0",
     "ember-template-lint": "^7.9.3",
     "ember-welcome-page": "^8.0.5",
     "eslint": "^9.39.2",

--- a/ember-primitives/src/components/resizable.css
+++ b/ember-primitives/src/components/resizable.css
@@ -1,0 +1,38 @@
+.ember-primitives__resizable {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.ember-primitives__resizable[data-orientation="horizontal"] {
+  flex-direction: row;
+}
+
+.ember-primitives__resizable[data-orientation="vertical"] {
+  flex-direction: column;
+}
+
+.ember-primitives__resizable__panel {
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+}
+
+.ember-primitives__resizable__handle {
+  flex: 0 0 auto;
+  position: relative;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.ember-primitives__resizable[data-orientation="horizontal"] > .ember-primitives__resizable__handle {
+  width: 0.5rem;
+  cursor: col-resize;
+}
+
+.ember-primitives__resizable[data-orientation="vertical"] > .ember-primitives__resizable__handle {
+  height: 0.5rem;
+  cursor: row-resize;
+}

--- a/ember-primitives/src/components/resizable.css
+++ b/ember-primitives/src/components/resizable.css
@@ -14,6 +14,8 @@
 }
 
 .ember-primitives__resizable__panel {
+  /* until the group assigns sizes, share space equally */
+  flex: 1 1 0px;
   overflow: hidden;
   min-width: 0;
   min-height: 0;
@@ -27,12 +29,12 @@
   -webkit-user-select: none;
 }
 
-.ember-primitives__resizable[data-orientation="horizontal"] > .ember-primitives__resizable__handle {
+.ember-primitives__resizable__handle[data-orientation="horizontal"] {
   width: 0.5rem;
   cursor: col-resize;
 }
 
-.ember-primitives__resizable[data-orientation="vertical"] > .ember-primitives__resizable__handle {
+.ember-primitives__resizable__handle[data-orientation="vertical"] {
   height: 0.5rem;
   cursor: row-resize;
 }

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -169,5 +169,3 @@ export class Resizable extends Component<Signature> {
     </div>
   </template>
 }
-
-export default Resizable;

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -52,17 +52,28 @@ export interface PanelSignature {
  * discovers them with DOM queries -- there is no registration, and a
  * Panel may contain another `<Resizable>` to nest layouts.
  */
+let panelId = 0;
+
+function nextPanelId(): string {
+  return `ember-primitives__resizable__panel--${panelId++}`;
+}
+
 export const Panel: TOC<PanelSignature> = <template>
-  <div
-    class="ember-primitives__resizable__panel"
-    data-min-size={{@minSize}}
-    data-max-size={{@maxSize}}
-    data-size={{@size}}
-    data-collapsible={{if @collapsible "true"}}
-    ...attributes
-  >
-    {{yield}}
-  </div>
+  {{#let (nextPanelId) as |id|}}
+    <div
+      class="ember-primitives__resizable__panel"
+      data-min-size={{@minSize}}
+      data-max-size={{@maxSize}}
+      data-size={{@size}}
+      data-collapsible={{if @collapsible "true"}}
+      ...attributes
+      {{! after ...attributes: the id is component-owned (the handles'
+          aria-controls depends on it being present and unique) }}
+      id={{id}}
+    >
+      {{yield}}
+    </div>
+  {{/let}}
 </template>;
 
 export interface HandleSignature {

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -1,0 +1,205 @@
+import "./resizable.css";
+
+import Component from "@glimmer/component";
+import { hash } from "@ember/helper";
+import { on } from "@ember/modifier";
+
+import { modifier } from "ember-modifier";
+
+import { GroupState, HandleState, PanelState } from "./resizable/state.ts";
+
+import type { Orientation } from "./resizable/state.ts";
+import type { WithBoundArgs } from "@glint/template";
+
+export type { Orientation };
+
+export interface PanelSignature {
+  Element: HTMLDivElement;
+  Args: {
+    /**
+     * @internal
+     * Provided by the containing `<Resizable>`.
+     */
+    state: GroupState;
+    /**
+     * The smallest size (in % of the group) this panel may be resized to.
+     * Defaults to 0.
+     */
+    minSize?: number;
+    /**
+     * The largest size (in % of the group) this panel may be resized to.
+     * Defaults to 100.
+     */
+    maxSize?: number;
+    /**
+     * The initial size (in % of the group).
+     * Panels without a defaultSize share the remaining space equally.
+     */
+    defaultSize?: number;
+    /**
+     * When true, pressing Enter on the handle after this panel
+     * collapses the panel to 0 (and restores it on the next press).
+     */
+    collapsible?: boolean;
+  };
+  Blocks: {
+    default: [
+      {
+        /**
+         * Whether this panel is currently collapsed.
+         */
+        isCollapsed: boolean;
+      },
+    ];
+  };
+}
+
+class Panel extends Component<PanelSignature> {
+  panelState = new PanelState({
+    minSize: () => this.args.minSize,
+    maxSize: () => this.args.maxSize,
+    defaultSize: () => this.args.defaultSize,
+    collapsible: () => this.args.collapsible,
+  });
+
+  register = modifier((element: HTMLElement) => {
+    this.panelState.element = element;
+    this.args.state.registerPanel(this.panelState);
+
+    return () => this.args.state.unregisterPanel(this.panelState);
+  });
+
+  <template>
+    <div
+      id={{this.panelState.id}}
+      class="ember-primitives__resizable__panel"
+      data-collapsed={{if this.panelState.isCollapsed "true"}}
+      style={{this.panelState.style}}
+      {{this.register}}
+      ...attributes
+    >
+      {{yield (hash isCollapsed=this.panelState.isCollapsed)}}
+    </div>
+  </template>
+}
+
+export interface HandleSignature {
+  Element: HTMLDivElement;
+  Args: {
+    /**
+     * @internal
+     * Provided by the containing `<Resizable>`.
+     */
+    state: GroupState;
+  };
+  Blocks: {
+    default: [];
+  };
+}
+
+class Handle extends Component<HandleSignature> {
+  handleState = new HandleState(this.args.state);
+
+  register = modifier((element: HTMLElement) => {
+    this.handleState.element = element;
+  });
+
+  onPointerDown = (event: PointerEvent) => {
+    if (this.handleState.element) {
+      this.args.state.startDrag(this.handleState.element, event);
+    }
+  };
+
+  onKeyDown = (event: KeyboardEvent) => {
+    if (this.handleState.element) {
+      this.args.state.handleKeyDown(this.handleState.element, event);
+    }
+  };
+
+  <template>
+    <div
+      class="ember-primitives__resizable__handle"
+      role="separator"
+      tabindex="0"
+      data-orientation={{this.args.state.orientation}}
+      aria-orientation={{this.handleState.ariaOrientation}}
+      aria-valuenow={{this.handleState.valueNow}}
+      aria-valuemin={{this.handleState.valueMin}}
+      aria-valuemax={{this.handleState.valueMax}}
+      aria-controls={{this.handleState.controls}}
+      {{this.register}}
+      {{on "pointerdown" this.onPointerDown}}
+      {{on "keydown" this.onKeyDown}}
+      ...attributes
+    >
+      {{yield}}
+    </div>
+  </template>
+}
+
+export interface Signature {
+  Element: HTMLDivElement;
+  Args: {
+    /**
+     * Which direction the panels are laid out in.
+     *
+     * `horizontal` (the default) places panels side-by-side (resizing along the x-axis),
+     * `vertical` stacks them (resizing along the y-axis).
+     */
+    orientation?: Orientation;
+    /**
+     * Called with the panels' sizes (percentages, in document order)
+     * whenever the layout changes.
+     *
+     * Useful for persisting the layout.
+     */
+    onLayoutChange?: (sizes: number[]) => void;
+  };
+  Blocks: {
+    default: [
+      {
+        /**
+         * A resizable region.
+         *
+         * A `<Resizable>` may be rendered inside a Panel to
+         * create nested (tree-shaped) layouts.
+         */
+        Panel: WithBoundArgs<typeof Panel, "state">;
+        /**
+         * The draggable (and keyboard-operable) divider between two Panels.
+         *
+         * Follows the WAI-ARIA window-splitter pattern, and controls
+         * the Panel immediately before it.
+         */
+        Handle: WithBoundArgs<typeof Handle, "state">;
+      },
+    ];
+  };
+}
+
+/**
+ * A group of resizable panels, separated by draggable handles.
+ *
+ * Groups can be nested (a `<Resizable>` inside a Panel) to build
+ * tree-shaped tiling layouts, i3 / tmux style.
+ */
+export class Resizable extends Component<Signature> {
+  state = new GroupState({
+    orientation: () => this.args.orientation,
+    onLayoutChange: () => this.args.onLayoutChange,
+  });
+
+  <template>
+    <div
+      class="ember-primitives__resizable"
+      data-orientation={{this.state.orientation}}
+      ...attributes
+    >
+      {{yield
+        (hash Panel=(component Panel state=this.state) Handle=(component Handle state=this.state))
+      }}
+    </div>
+  </template>
+}
+
+export default Resizable;

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -6,7 +6,6 @@ import { on } from "@ember/modifier";
 import { modifier } from "ember-modifier";
 
 import { Consume, Provide } from "../dom-context.gts";
-import { uniqueId } from "../utils.ts";
 import { GroupState } from "./resizable/state.ts";
 
 import type { Orientation } from "./resizable/state.ts";
@@ -54,19 +53,16 @@ export interface PanelSignature {
  * Panel may contain another `<Resizable>` to nest layouts.
  */
 export const Panel: TOC<PanelSignature> = <template>
-  {{#let (uniqueId) as |id|}}
-    <div
-      id={{id}}
-      class="ember-primitives__resizable__panel"
-      data-min-size={{@minSize}}
-      data-max-size={{@maxSize}}
-      data-size={{@size}}
-      data-collapsible={{if @collapsible "true"}}
-      ...attributes
-    >
-      {{yield}}
-    </div>
-  {{/let}}
+  <div
+    class="ember-primitives__resizable__panel"
+    data-min-size={{@minSize}}
+    data-max-size={{@maxSize}}
+    data-size={{@size}}
+    data-collapsible={{if @collapsible "true"}}
+    ...attributes
+  >
+    {{yield}}
+  </div>
 </template>;
 
 export interface HandleSignature {

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -59,21 +59,19 @@ function nextPanelId(): string {
 }
 
 export const Panel: TOC<PanelSignature> = <template>
-  {{#let (nextPanelId) as |id|}}
-    <div
-      class="ember-primitives__resizable__panel"
-      data-min-size={{@minSize}}
-      data-max-size={{@maxSize}}
-      data-size={{@size}}
-      data-collapsible={{if @collapsible "true"}}
-      ...attributes
-      {{! after ...attributes: the id is component-owned (the handles'
-          aria-controls depends on it being present and unique) }}
-      id={{id}}
-    >
-      {{yield}}
-    </div>
-  {{/let}}
+  <div
+    class="ember-primitives__resizable__panel"
+    data-min-size={{@minSize}}
+    data-max-size={{@maxSize}}
+    data-size={{@size}}
+    data-collapsible={{if @collapsible "true"}}
+    ...attributes
+    {{! after ...attributes: the id is component-owned (the handles'
+        aria-controls depends on it being present and unique) }}
+    id={{(nextPanelId)}}
+  >
+    {{yield}}
+  </div>
 </template>;
 
 export interface HandleSignature {

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -6,6 +6,7 @@ import { on } from "@ember/modifier";
 import { modifier } from "ember-modifier";
 
 import { Consume, Provide } from "../dom-context.gts";
+import { uniqueId } from "../utils.ts";
 import { GroupState } from "./resizable/state.ts";
 
 import type { Orientation } from "./resizable/state.ts";
@@ -53,16 +54,19 @@ export interface PanelSignature {
  * Panel may contain another `<Resizable>` to nest layouts.
  */
 export const Panel: TOC<PanelSignature> = <template>
-  <div
-    class="ember-primitives__resizable__panel"
-    data-min-size={{@minSize}}
-    data-max-size={{@maxSize}}
-    data-size={{@size}}
-    data-collapsible={{if @collapsible "true"}}
-    ...attributes
-  >
-    {{yield}}
-  </div>
+  {{#let (uniqueId) as |id|}}
+    <div
+      id={{id}}
+      class="ember-primitives__resizable__panel"
+      data-min-size={{@minSize}}
+      data-max-size={{@maxSize}}
+      data-size={{@size}}
+      data-collapsible={{if @collapsible "true"}}
+      ...attributes
+    >
+      {{yield}}
+    </div>
+  {{/let}}
 </template>;
 
 export interface HandleSignature {

--- a/ember-primitives/src/components/resizable.gts
+++ b/ember-primitives/src/components/resizable.gts
@@ -1,26 +1,21 @@
 import "./resizable.css";
 
 import Component from "@glimmer/component";
-import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 
 import { modifier } from "ember-modifier";
 
-import { GroupState, HandleState, PanelState } from "./resizable/state.ts";
+import { Consume, Provide } from "../dom-context.gts";
+import { GroupState } from "./resizable/state.ts";
 
 import type { Orientation } from "./resizable/state.ts";
-import type { WithBoundArgs } from "@glint/template";
+import type { TOC } from "@ember/component/template-only";
 
 export type { Orientation };
 
 export interface PanelSignature {
   Element: HTMLDivElement;
   Args: {
-    /**
-     * @internal
-     * Provided by the containing `<Resizable>`.
-     */
-    state: GroupState;
     /**
      * The smallest size (in % of the group) this panel may be resized to.
      * Defaults to 0.
@@ -33,109 +28,82 @@ export interface PanelSignature {
     maxSize?: number;
     /**
      * The initial size (in % of the group).
-     * Panels without a defaultSize share the remaining space equally.
+     * Panels without a size share the remaining space equally.
      */
-    defaultSize?: number;
+    size?: number;
     /**
      * When true, pressing Enter on the handle after this panel
-     * collapses the panel to 0 (and restores it on the next press).
+     * collapses the panel to 0 (and restores it on the next press),
+     * and dragging well past `@minSize` snaps it closed.
+     *
+     * While collapsed, the panel has a `data-collapsed` attribute.
      */
     collapsible?: boolean;
-  };
-  Blocks: {
-    default: [
-      {
-        /**
-         * Whether this panel is currently collapsed.
-         */
-        isCollapsed: boolean;
-      },
-    ];
-  };
-}
-
-class Panel extends Component<PanelSignature> {
-  panelState = new PanelState({
-    minSize: () => this.args.minSize,
-    maxSize: () => this.args.maxSize,
-    defaultSize: () => this.args.defaultSize,
-    collapsible: () => this.args.collapsible,
-  });
-
-  register = modifier((element: HTMLElement) => {
-    this.panelState.element = element;
-    this.args.state.registerPanel(this.panelState);
-
-    return () => this.args.state.unregisterPanel(this.panelState);
-  });
-
-  <template>
-    <div
-      id={{this.panelState.id}}
-      class="ember-primitives__resizable__panel"
-      data-collapsed={{if this.panelState.isCollapsed "true"}}
-      style={{this.panelState.style}}
-      {{this.register}}
-      ...attributes
-    >
-      {{yield (hash isCollapsed=this.panelState.isCollapsed)}}
-    </div>
-  </template>
-}
-
-export interface HandleSignature {
-  Element: HTMLDivElement;
-  Args: {
-    /**
-     * @internal
-     * Provided by the containing `<Resizable>`.
-     */
-    state: GroupState;
   };
   Blocks: {
     default: [];
   };
 }
 
-class Handle extends Component<HandleSignature> {
-  handleState = new HandleState(this.args.state);
+/**
+ * A resizable region within a `<Resizable>` group.
+ *
+ * Panels declare their constraints as data attributes, so the group
+ * discovers them with DOM queries -- there is no registration, and a
+ * Panel may contain another `<Resizable>` to nest layouts.
+ */
+export const Panel: TOC<PanelSignature> = <template>
+  <div
+    class="ember-primitives__resizable__panel"
+    data-min-size={{@minSize}}
+    data-max-size={{@maxSize}}
+    data-size={{@size}}
+    data-collapsible={{if @collapsible "true"}}
+    ...attributes
+  >
+    {{yield}}
+  </div>
+</template>;
 
-  register = modifier((element: HTMLElement) => {
-    this.handleState.element = element;
-  });
-
-  onPointerDown = (event: PointerEvent) => {
-    if (this.handleState.element) {
-      this.args.state.startDrag(this.handleState.element, event);
-    }
+export interface HandleSignature {
+  Element: HTMLDivElement;
+  Blocks: {
+    default: [];
   };
+}
 
-  onKeyDown = (event: KeyboardEvent) => {
-    if (this.handleState.element) {
-      this.args.state.handleKeyDown(this.handleState.element, event);
-    }
-  };
+function onPointerDown(state: GroupState) {
+  return (event: PointerEvent) => state.startDrag(event.currentTarget as HTMLElement, event);
+}
 
-  <template>
+function onKeyDown(state: GroupState) {
+  return (event: KeyboardEvent) => state.handleKeyDown(event.currentTarget as HTMLElement, event);
+}
+
+/**
+ * The draggable (and keyboard-operable) divider between two Panels.
+ *
+ * Follows the WAI-ARIA window-splitter pattern, and controls the Panel
+ * immediately before it. Finds its group via DOM context, so it must be
+ * rendered inside a `<Resizable>`.
+ *
+ * Give each handle an accessible name (e.g. `aria-label="Resize sidebar"`).
+ */
+export const Handle: TOC<HandleSignature> = <template>
+  <Consume @key={{GroupState}} as |ctx|>
     <div
       class="ember-primitives__resizable__handle"
       role="separator"
       tabindex="0"
-      data-orientation={{this.args.state.orientation}}
-      aria-orientation={{this.handleState.ariaOrientation}}
-      aria-valuenow={{this.handleState.valueNow}}
-      aria-valuemin={{this.handleState.valueMin}}
-      aria-valuemax={{this.handleState.valueMax}}
-      aria-controls={{this.handleState.controls}}
-      {{this.register}}
-      {{on "pointerdown" this.onPointerDown}}
-      {{on "keydown" this.onKeyDown}}
+      data-orientation={{ctx.data.orientation}}
+      {{on "pointerdown" (onPointerDown ctx.data)}}
+      {{on "keydown" (onKeyDown ctx.data)}}
       ...attributes
     >
       {{yield}}
     </div>
-  </template>
-}
+  </Consume>
+</template>;
 
 export interface Signature {
   Element: HTMLDivElement;
@@ -145,6 +113,8 @@ export interface Signature {
      *
      * `horizontal` (the default) places panels side-by-side (resizing along the x-axis),
      * `vertical` stacks them (resizing along the y-axis).
+     *
+     * May be changed while rendered; panels keep their sizes.
      */
     orientation?: Orientation;
     /**
@@ -156,29 +126,15 @@ export interface Signature {
     onLayoutChange?: (sizes: number[]) => void;
   };
   Blocks: {
-    default: [
-      {
-        /**
-         * A resizable region.
-         *
-         * A `<Resizable>` may be rendered inside a Panel to
-         * create nested (tree-shaped) layouts.
-         */
-        Panel: WithBoundArgs<typeof Panel, "state">;
-        /**
-         * The draggable (and keyboard-operable) divider between two Panels.
-         *
-         * Follows the WAI-ARIA window-splitter pattern, and controls
-         * the Panel immediately before it.
-         */
-        Handle: WithBoundArgs<typeof Handle, "state">;
-      },
-    ];
+    default: [];
   };
 }
 
 /**
  * A group of resizable panels, separated by draggable handles.
+ *
+ * Render `<Panel>` and `<Handle>` components inside -- they are their
+ * own imports, and find the group via DOM context / DOM queries.
  *
  * Groups can be nested (a `<Resizable>` inside a Panel) to build
  * tree-shaped tiling layouts, i3 / tmux style.
@@ -189,15 +145,18 @@ export class Resizable extends Component<Signature> {
     onLayoutChange: () => this.args.onLayoutChange,
   });
 
+  attach = modifier((element: HTMLElement) => this.state.attach(element));
+
   <template>
     <div
       class="ember-primitives__resizable"
       data-orientation={{this.state.orientation}}
+      {{this.attach}}
       ...attributes
     >
-      {{yield
-        (hash Panel=(component Panel state=this.state) Handle=(component Handle state=this.state))
-      }}
+      <Provide @data={{this.state}} @key={{GroupState}}>
+        {{yield}}
+      </Provide>
     </div>
   </template>
 }

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -430,6 +430,9 @@ export class GroupState {
 
       if (!prev) continue;
 
+      // Panels render their own (component-owned, incrementing) id
+      if (prev.id) setAttribute(handle, 'aria-controls', prev.id);
+
       setAttribute(handle, 'aria-valuemin', `${minSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuemax', `${maxSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -190,6 +190,8 @@ export class GroupState {
     subtree: true,
     attributes: true,
     attributeFilter: ['data-orientation'],
+    // to distinguish real changes from same-value writes (see below)
+    attributeOldValue: true,
   };
 
   static #handleMutations(mutations: MutationRecord[]): void {
@@ -207,7 +209,16 @@ export class GroupState {
       if (mutation.type === 'attributes') {
         const group = GroupState.#observed.get(target as HTMLElement);
 
-        if (group) affected.set(group, true);
+        /**
+         * setAttribute queues a record even when the value is
+         * unchanged (renderers do rewrite attributes with the same
+         * value); only actual changes warrant a relayout.
+         */
+        const changed =
+          mutation.attributeName &&
+          mutation.oldValue !== target.getAttribute(mutation.attributeName);
+
+        if (group && changed) affected.set(group, true);
         continue;
       }
 

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -316,15 +316,38 @@ export class GroupState {
     baseNextSize: number,
     requestedDelta: number
   ): void {
-    const minDelta = Math.max(prev.minSize - basePrevSize, baseNextSize - next.maxSize);
-    const maxDelta = Math.min(prev.maxSize - basePrevSize, baseNextSize - next.minSize);
+    const total = basePrevSize + baseNextSize;
 
-    if (minDelta > maxDelta) return;
+    let target = basePrevSize + requestedDelta;
 
-    const delta = clamp(requestedDelta, minDelta, maxDelta);
+    if (prev.collapsible && target < prev.minSize) {
+      /**
+       * Collapsible panels snap: below half the minimum they close
+       * entirely; between half and the minimum they hold at the minimum.
+       * (This also keeps a collapsed panel closed when its handle is
+       * dragged further in the closing direction.)
+       */
+      target = target < prev.minSize / 2 ? 0 : prev.minSize;
+    } else {
+      target = clamp(target, prev.minSize, prev.maxSize);
+    }
 
-    prev.size = basePrevSize + delta;
-    next.size = baseNextSize - delta;
+    /**
+     * The neighbor absorbs whatever the target panel gives or takes,
+     * so its constraints bound the target too.
+     */
+    const nextMin = total - next.maxSize;
+    const nextMax = total - next.minSize;
+
+    if (nextMin > nextMax) return;
+
+    target = clamp(target, nextMin, nextMax);
+
+    // both panels' constraints cannot be satisfied at once
+    if (!prev.collapsible && (target < prev.minSize || target > prev.maxSize)) return;
+
+    prev.size = target;
+    next.size = total - target;
 
     this.#notify();
   }

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -1,0 +1,545 @@
+import { tracked } from '@glimmer/tracking';
+import { guidFor } from '@ember/object/internals';
+import { scheduleOnce } from '@ember/runloop';
+import { htmlSafe } from '@ember/template';
+
+/**
+ * `style` attribute values need to be SafeStrings to avoid Ember's
+ * style-binding warning.
+ */
+export type StyleString = ReturnType<typeof htmlSafe>;
+
+export type Orientation = 'horizontal' | 'vertical';
+
+const DEFAULT_MIN = 0;
+const DEFAULT_MAX = 100;
+
+/**
+ * Sizes are percentages (floats). Below this threshold a collapsible
+ * panel is considered collapsed.
+ */
+const COLLAPSED_EPSILON = 0.5;
+
+/**
+ * How far (in %) one keyboard arrow press moves a handle.
+ * Holding Shift moves in coarser increments.
+ */
+const KEYBOARD_STEP = 1;
+const KEYBOARD_STEP_COARSE = 10;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+interface PanelOptions {
+  minSize: () => number | undefined;
+  maxSize: () => number | undefined;
+  defaultSize: () => number | undefined;
+  collapsible: () => boolean | undefined;
+}
+
+export class PanelState {
+  /**
+   * The panel's current size, as a percentage of the group's panel-space
+   * (the group's size minus the space occupied by the handles).
+   *
+   * `null` until the group has performed its first layout.
+   */
+  @tracked size: number | null = null;
+
+  /**
+   * The size (%) this panel had before it was collapsed,
+   * so that expanding restores it.
+   */
+  previousSize: number | null = null;
+
+  element: HTMLElement | null = null;
+
+  #options: PanelOptions;
+
+  constructor(options: PanelOptions) {
+    this.#options = options;
+  }
+
+  get id(): string {
+    return guidFor(this);
+  }
+
+  get minSize(): number {
+    return this.#options.minSize() ?? DEFAULT_MIN;
+  }
+
+  get maxSize(): number {
+    return this.#options.maxSize() ?? DEFAULT_MAX;
+  }
+
+  get defaultSize(): number | undefined {
+    return this.#options.defaultSize();
+  }
+
+  get collapsible(): boolean {
+    return this.#options.collapsible() ?? false;
+  }
+
+  get isCollapsed(): boolean {
+    return this.collapsible && this.size !== null && this.size <= COLLAPSED_EPSILON;
+  }
+
+  /**
+   * Percentage-based flex-grow keeps sizing proportional without
+   * needing to measure anything during render.
+   */
+  get style(): StyleString {
+    if (this.size === null) {
+      return htmlSafe(`flex: 1 1 0px;`);
+    }
+
+    return htmlSafe(`flex: ${this.size} 1 0px;`);
+  }
+}
+
+interface DragState {
+  prev: PanelState;
+  next: PanelState;
+  startPrevSize: number;
+  startNextSize: number;
+  startCoordinate: number;
+  /**
+   * Total px occupied by the panels (excluding handles) at drag start,
+   * used to convert px deltas to % deltas.
+   */
+  totalPx: number;
+  move: (event: PointerEvent) => void;
+  end: (event: PointerEvent) => void;
+}
+
+interface GroupOptions {
+  orientation: () => Orientation | undefined;
+  onLayoutChange: () => ((sizes: number[]) => void) | undefined;
+}
+
+export class GroupState {
+  /**
+   * Panels in document order. Only assigned during the scheduled sync,
+   * never during render (avoids backtracking re-render assertions).
+   */
+  @tracked panels: PanelState[] = [];
+
+  #registered: PanelState[] = [];
+  #options: GroupOptions;
+  #drag: DragState | null = null;
+
+  constructor(options: GroupOptions) {
+    this.#options = options;
+  }
+
+  get orientation(): Orientation {
+    return this.#options.orientation() ?? 'horizontal';
+  }
+
+  get #isHorizontal(): boolean {
+    return this.orientation === 'horizontal';
+  }
+
+  get sizes(): number[] {
+    return this.panels.map((panel) => panel.size ?? 0);
+  }
+
+  registerPanel(panel: PanelState): void {
+    this.#registered.push(panel);
+    this.#scheduleSync();
+  }
+
+  unregisterPanel(panel: PanelState): void {
+    this.#registered = this.#registered.filter((existing) => existing !== panel);
+    this.#scheduleSync();
+  }
+
+  #scheduleSync(): void {
+    // eslint-disable-next-line ember/no-runloop
+    scheduleOnce('afterRender', this, this.#sync);
+  }
+
+  /**
+   * Commits registration changes and (re)computes the layout.
+   * Runs after render so that tracked state consumed by sibling panels
+   * is never written to mid-render.
+   */
+  #sync = (): void => {
+    const connected = this.#registered.filter((panel) => panel.element?.isConnected);
+
+    connected.sort((a, b) => {
+      if (!a.element || !b.element) return 0;
+
+      /**
+       * a.element precedes b.element => bitmask includes "preceding" from b's perspective
+       */
+      const position = b.element.compareDocumentPosition(a.element);
+
+      return position & Node.DOCUMENT_POSITION_PRECEDING ? -1 : 1;
+    });
+
+    this.panels = connected;
+    this.#layout();
+  };
+
+  /**
+   * Panels that already have a size (or declare a defaultSize) keep it,
+   * new panels take an equal share, then everything is normalized to 100.
+   */
+  #layout(): void {
+    const panels = this.panels;
+
+    if (panels.length === 0) return;
+
+    const specified: PanelState[] = [];
+    const unspecified: PanelState[] = [];
+    let specifiedTotal = 0;
+
+    for (const panel of panels) {
+      const preferred = panel.size ?? panel.defaultSize;
+
+      if (preferred === undefined) {
+        unspecified.push(panel);
+        continue;
+      }
+
+      panel.size = panel.isCollapsed ? panel.size : clamp(preferred, panel.minSize, panel.maxSize);
+      specified.push(panel);
+      specifiedTotal += panel.size ?? 0;
+    }
+
+    if (unspecified.length > 0) {
+      /**
+       * Panels without a (default)size share the remaining space.
+       * When there is none left (e.g. a panel was added to an
+       * already-full group), each takes an equal 1/n share and the
+       * existing panels scale down to make room -- like a new window
+       * opening in a tiling window manager.
+       */
+      const remaining = 100 - specifiedTotal;
+      let share = remaining / unspecified.length;
+
+      if (remaining < 1) {
+        share = 100 / panels.length;
+
+        if (specifiedTotal > 0) {
+          const scale = Math.max(100 - share * unspecified.length, 0) / specifiedTotal;
+
+          for (const panel of specified) {
+            panel.size = (panel.size ?? 0) * scale;
+          }
+        }
+      }
+
+      for (const panel of unspecified) {
+        panel.size = clamp(share, panel.minSize, panel.maxSize);
+      }
+    }
+
+    this.#normalize();
+    this.#notify();
+  }
+
+  #normalize(): void {
+    const panels = this.panels;
+    const total = panels.reduce((sum, panel) => sum + (panel.size ?? 0), 0);
+
+    if (total <= 0 || Math.abs(total - 100) < 0.01) return;
+
+    for (const panel of panels) {
+      panel.size = ((panel.size ?? 0) / total) * 100;
+    }
+  }
+
+  #notify(): void {
+    this.#options.onLayoutChange()?.(this.sizes);
+  }
+
+  /**
+   * Re-derive percentage sizes from actual rendered pixels.
+   * Corrects any drift (e.g. from CSS min-sizes) before an interaction.
+   */
+  #syncSizesFromDOM(): void {
+    const panels = this.panels;
+    const px = panels.map((panel) => this.#pixelSizeOf(panel));
+    const total = px.reduce((sum, value) => sum + value, 0);
+
+    if (total <= 0) return;
+
+    panels.forEach((panel, index) => {
+      panel.size = ((px[index] ?? 0) / total) * 100;
+    });
+  }
+
+  #pixelSizeOf(panel: PanelState): number {
+    const box = panel.element?.getBoundingClientRect();
+
+    if (!box) return 0;
+
+    return this.#isHorizontal ? box.width : box.height;
+  }
+
+  /**
+   * The panels immediately before and after the given handle element,
+   * in document order.
+   */
+  neighborsOf(handleElement: HTMLElement): [PanelState | null, PanelState | null] {
+    let prev: PanelState | null = null;
+    let next: PanelState | null = null;
+
+    for (const panel of this.panels) {
+      if (!panel.element) continue;
+
+      const position = handleElement.compareDocumentPosition(panel.element);
+
+      if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+        prev = panel;
+      } else if (position & Node.DOCUMENT_POSITION_FOLLOWING) {
+        next = panel;
+
+        break;
+      }
+    }
+
+    return [prev, next];
+  }
+
+  /**
+   * Moves the boundary between the two panels by `requestedDelta` (%),
+   * respecting both panels' min/max constraints.
+   */
+  #applyDelta(
+    prev: PanelState,
+    next: PanelState,
+    basePrevSize: number,
+    baseNextSize: number,
+    requestedDelta: number
+  ): void {
+    const minDelta = Math.max(prev.minSize - basePrevSize, baseNextSize - next.maxSize);
+    const maxDelta = Math.min(prev.maxSize - basePrevSize, baseNextSize - next.minSize);
+
+    if (minDelta > maxDelta) return;
+
+    const delta = clamp(requestedDelta, minDelta, maxDelta);
+
+    prev.size = basePrevSize + delta;
+    next.size = baseNextSize - delta;
+
+    this.#notify();
+  }
+
+  startDrag(handleElement: HTMLElement, event: PointerEvent): void {
+    if (event.button !== 0) return;
+    if (this.#drag) return;
+
+    const [prev, next] = this.neighborsOf(handleElement);
+
+    if (!prev || !next) return;
+
+    this.#syncSizesFromDOM();
+
+    const move = (moveEvent: PointerEvent) => this.#dragMove(moveEvent);
+    const end = (endEvent: PointerEvent) => this.#endDrag(handleElement, endEvent);
+
+    this.#drag = {
+      prev,
+      next,
+      startPrevSize: prev.size ?? 0,
+      startNextSize: next.size ?? 0,
+      startCoordinate: this.#isHorizontal ? event.clientX : event.clientY,
+      totalPx: this.panels.reduce((sum, panel) => sum + this.#pixelSizeOf(panel), 0),
+      move,
+      end,
+    };
+
+    try {
+      /**
+       * Retargets all subsequent pointer events to the handle,
+       * even when the pointer is over an iframe.
+       */
+      handleElement.setPointerCapture(event.pointerId);
+    } catch {
+      // synthetic events (tests) may not have an active pointer
+    }
+
+    handleElement.addEventListener('pointermove', this.#drag.move);
+    handleElement.addEventListener('pointerup', this.#drag.end);
+    handleElement.addEventListener('pointercancel', this.#drag.end);
+    handleElement.setAttribute('data-resizing', '');
+
+    document.body.style.cursor = this.#isHorizontal ? 'col-resize' : 'row-resize';
+    document.body.style.userSelect = 'none';
+  }
+
+  #dragMove(event: PointerEvent): void {
+    const drag = this.#drag;
+
+    if (!drag) return;
+    if (drag.totalPx <= 0) return;
+
+    const coordinate = this.#isHorizontal ? event.clientX : event.clientY;
+    const deltaPercent = ((coordinate - drag.startCoordinate) / drag.totalPx) * 100;
+
+    this.#applyDelta(drag.prev, drag.next, drag.startPrevSize, drag.startNextSize, deltaPercent);
+  }
+
+  #endDrag(handleElement: HTMLElement, event: PointerEvent): void {
+    const drag = this.#drag;
+
+    if (!drag) return;
+
+    this.#drag = null;
+
+    try {
+      handleElement.releasePointerCapture(event.pointerId);
+    } catch {
+      // may not have been captured (tests)
+    }
+
+    handleElement.removeEventListener('pointermove', drag.move);
+    handleElement.removeEventListener('pointerup', drag.end);
+    handleElement.removeEventListener('pointercancel', drag.end);
+    handleElement.removeAttribute('data-resizing');
+
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+  }
+
+  /**
+   * Keyboard support for the WAI-ARIA window-splitter pattern.
+   */
+  handleKeyDown(handleElement: HTMLElement, event: KeyboardEvent): void {
+    const [prev, next] = this.neighborsOf(handleElement);
+
+    if (!prev || !next) return;
+
+    if (event.key === 'Enter') {
+      this.toggleCollapse(handleElement);
+
+      return;
+    }
+
+    const step = event.shiftKey ? KEYBOARD_STEP_COARSE : KEYBOARD_STEP;
+    const isHorizontal = this.#isHorizontal;
+
+    let delta: number | null = null;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        if (isHorizontal) delta = -step;
+
+        break;
+      case 'ArrowRight':
+        if (isHorizontal) delta = step;
+
+        break;
+      case 'ArrowUp':
+        if (!isHorizontal) delta = -step;
+
+        break;
+      case 'ArrowDown':
+        if (!isHorizontal) delta = step;
+
+        break;
+      case 'Home':
+        this.#syncSizesFromDOM();
+        delta = prev.minSize - (prev.size ?? 0);
+
+        break;
+      case 'End':
+        this.#syncSizesFromDOM();
+        delta = prev.maxSize - (prev.size ?? 0);
+
+        break;
+    }
+
+    if (delta === null) return;
+
+    event.preventDefault();
+
+    this.#syncSizesFromDOM();
+    this.#applyDelta(prev, next, prev.size ?? 0, next.size ?? 0, delta);
+  }
+
+  /**
+   * Collapses (or restores) the panel before the handle,
+   * giving the space to (or taking it from) the panel after it.
+   *
+   * Only does anything when the preceding panel is `@collapsible`.
+   */
+  toggleCollapse(handleElement: HTMLElement): void {
+    const [prev, next] = this.neighborsOf(handleElement);
+
+    if (!prev || !next) return;
+    if (!prev.collapsible) return;
+
+    this.#syncSizesFromDOM();
+
+    const prevSize = prev.size ?? 0;
+    const nextSize = next.size ?? 0;
+
+    if (prev.isCollapsed) {
+      const preferred = prev.previousSize ?? prev.defaultSize ?? Math.max(prev.minSize, 10);
+      const available = nextSize - next.minSize;
+      const restored = Math.min(preferred, available);
+
+      if (restored <= 0) return;
+
+      prev.size = restored;
+      next.size = nextSize - restored;
+    } else {
+      prev.previousSize = prevSize;
+      prev.size = 0;
+      next.size = nextSize + prevSize;
+    }
+
+    this.#notify();
+  }
+}
+
+export class HandleState {
+  @tracked element: HTMLElement | null = null;
+
+  #group: GroupState;
+
+  constructor(group: GroupState) {
+    this.#group = group;
+  }
+
+  get #neighbors(): [PanelState | null, PanelState | null] {
+    if (!this.element) return [null, null];
+
+    return this.#group.neighborsOf(this.element);
+  }
+
+  get #prevPanel(): PanelState | null {
+    return this.#neighbors[0];
+  }
+
+  /**
+   * Per the window-splitter pattern, a splitter between two side-by-side
+   * panes is oriented *vertically* (and vice-versa).
+   */
+  get ariaOrientation(): Orientation {
+    return this.#group.orientation === 'horizontal' ? 'vertical' : 'horizontal';
+  }
+
+  get valueNow(): number | undefined {
+    const size = this.#prevPanel?.size;
+
+    return size === null || size === undefined ? undefined : Math.round(size);
+  }
+
+  get valueMin(): number | undefined {
+    return this.#prevPanel?.minSize;
+  }
+
+  get valueMax(): number | undefined {
+    return this.#prevPanel?.maxSize;
+  }
+
+  get controls(): string | undefined {
+    return this.#prevPanel?.id;
+  }
+}

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -14,8 +14,6 @@ const DEFAULT_MAX = 100;
 const KEYBOARD_STEP = 1;
 const KEYBOARD_STEP_COARSE = 10;
 
-let panelId = 0;
-
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
@@ -432,10 +430,12 @@ export class GroupState {
 
       if (!prev) continue;
 
-      // Panels render their own id; this only fires for hand-written markup
-      if (!prev.id) prev.id = `ember-primitives__resizable__panel--${panelId++}`;
+      /**
+       * ids are global, so we never generate one -- but when the
+       * consumer gave their panel an id, the handle references it.
+       */
+      if (prev.id) setAttribute(handle, 'aria-controls', prev.id);
 
-      setAttribute(handle, 'aria-controls', prev.id);
       setAttribute(handle, 'aria-valuemin', `${minSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuemax', `${maxSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -64,6 +64,15 @@ function isSameSize(existing: number | undefined, size: number): boolean {
 }
 
 /**
+ * Pixel measurements round to device pixels, so re-measuring a layout
+ * yields values that differ from the stored ones by sub-pixel noise.
+ * Only differences beyond this (in %) count as real drift worth
+ * adopting -- re-encoding identical pixels as slightly different
+ * percentages would dirty every panel for no visual change.
+ */
+const MEASUREMENT_TOLERANCE = 0.25;
+
+/**
  * Skips the write when the attribute already has the desired value,
  * so unchanged elements are left untouched.
  */
@@ -296,31 +305,35 @@ export class GroupState {
      * value actually changed (with a small tolerance, so float dust
      * from re-normalizing doesn't count as a change).
      */
+    const changedPanels: HTMLElement[] = [];
+
     for (const [panel, size] of computed) {
       if (!isSameSize(this.#sizes.get(panel), size)) {
         this.#sizes.set(panel, size);
+        changedPanels.push(panel);
         changed = true;
       }
     }
 
-    this.#apply();
+    this.#apply(changedPanels);
 
     if (changed) this.#notify();
   }
 
   /**
-   * Writes the layout back to the DOM: flex sizing and the handles'
-   * ARIA attributes. (`data-collapsed` is managed at the explicit
-   * collapse/expand points, not derived from sizes -- rendered pixel
-   * sizes include borders/padding, so a collapsed panel rarely
-   * measures exactly 0.)
+   * Writes the layout back to the DOM: flex sizing for exactly the
+   * panels that changed, plus the handles' ARIA attributes (which are
+   * guarded per-attribute). (`data-collapsed` is managed at the
+   * explicit collapse/expand points, not derived from sizes --
+   * rendered pixel sizes include borders/padding, so a collapsed
+   * panel rarely measures exactly 0.)
    */
-  #apply(): void {
-    for (const [panel, size] of this.#sizes) {
-      const flex = `${size} 1 0px`;
+  #apply(changedPanels: HTMLElement[]): void {
+    for (const panel of changedPanels) {
+      const size = this.#sizes.get(panel);
 
-      if (panel.style.flex !== flex) {
-        panel.style.flex = flex;
+      if (size !== undefined) {
+        panel.style.flex = `${size} 1 0px`;
       }
     }
 
@@ -385,8 +398,9 @@ export class GroupState {
 
     panels.forEach((panel, index) => {
       const size = ((px[index] ?? 0) / total) * 100;
+      const existing = this.#sizes.get(panel);
 
-      if (!isSameSize(this.#sizes.get(panel), size)) {
+      if (existing === undefined || Math.abs(existing - size) > MEASUREMENT_TOLERANCE) {
         this.#sizes.set(panel, size);
       }
     });
@@ -484,7 +498,7 @@ export class GroupState {
     this.#sizes.set(prev, target);
     this.#sizes.set(next, total - target);
 
-    this.#apply();
+    this.#apply([prev, next]);
     this.#notify();
   }
 
@@ -653,7 +667,7 @@ export class GroupState {
       this.#sizes.set(next, nextSize + prevSize);
     }
 
-    this.#apply();
+    this.#apply([prev, next]);
     this.#notify();
   }
 }

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -211,12 +211,19 @@ export class GroupState {
 
     if (panels.length === 0) return;
 
+    let changed = false;
+
     // forget sizes of panels that left the DOM
     for (const known of Array.from(this.#sizes.keys())) {
-      if (!panels.includes(known)) this.#sizes.delete(known);
+      if (!panels.includes(known)) {
+        this.#sizes.delete(known);
+        changed = true;
+      }
     }
 
-    const next = new Map<HTMLElement, number>();
+    // scratch space for the math below; #sizes itself is only
+    // touched at the end, and only where values actually changed
+    const computed = new Map<HTMLElement, number>();
     const unspecified: HTMLElement[] = [];
     let specifiedTotal = 0;
 
@@ -232,7 +239,7 @@ export class GroupState {
         ? preferred
         : clamp(preferred, minSizeOf(panel), maxSizeOf(panel));
 
-      next.set(panel, size);
+      computed.set(panel, size);
       specifiedTotal += size;
     }
 
@@ -253,31 +260,45 @@ export class GroupState {
         if (specifiedTotal > 0) {
           const scale = Math.max(100 - share * unspecified.length, 0) / specifiedTotal;
 
-          for (const [panel, size] of next) {
-            next.set(panel, size * scale);
+          for (const [panel, size] of computed) {
+            computed.set(panel, size * scale);
           }
         }
       }
 
       for (const panel of unspecified) {
-        next.set(panel, clamp(share, minSizeOf(panel), maxSizeOf(panel)));
+        computed.set(panel, clamp(share, minSizeOf(panel), maxSizeOf(panel)));
       }
     }
 
     // normalize to 100
     let total = 0;
 
-    for (const size of next.values()) total += size;
+    for (const size of computed.values()) total += size;
 
     if (total > 0 && Math.abs(total - 100) > 0.01) {
-      for (const [panel, size] of next) {
-        next.set(panel, (size / total) * 100);
+      for (const [panel, size] of computed) {
+        computed.set(panel, (size / total) * 100);
       }
     }
 
-    this.#sizes = next;
+    /**
+     * Commit minimally: keep the #sizes map, update only entries whose
+     * value actually changed (with a small tolerance, so float dust
+     * from re-normalizing doesn't count as a change).
+     */
+    for (const [panel, size] of computed) {
+      const existing = this.#sizes.get(panel);
+
+      if (existing === undefined || Math.abs(existing - size) > 0.0001) {
+        this.#sizes.set(panel, size);
+        changed = true;
+      }
+    }
+
     this.#apply();
-    this.#notify();
+
+    if (changed) this.#notify();
   }
 
   /**

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -1,24 +1,11 @@
-import { tracked } from '@glimmer/tracking';
-import { guidFor } from '@ember/object/internals';
-import { scheduleOnce } from '@ember/runloop';
-import { htmlSafe } from '@ember/template';
-
-/**
- * `style` attribute values need to be SafeStrings to avoid Ember's
- * style-binding warning.
- */
-export type StyleString = ReturnType<typeof htmlSafe>;
-
 export type Orientation = 'horizontal' | 'vertical';
+
+const GROUP_SELECTOR = '.ember-primitives__resizable';
+const PANEL_SELECTOR = '.ember-primitives__resizable__panel';
+const HANDLE_SELECTOR = '.ember-primitives__resizable__handle';
 
 const DEFAULT_MIN = 0;
 const DEFAULT_MAX = 100;
-
-/**
- * Sizes are percentages (floats). Below this threshold a collapsible
- * panel is considered collapsed.
- */
-const COLLAPSED_EPSILON = 0.5;
 
 /**
  * How far (in %) one keyboard arrow press moves a handle.
@@ -27,80 +14,46 @@ const COLLAPSED_EPSILON = 0.5;
 const KEYBOARD_STEP = 1;
 const KEYBOARD_STEP_COARSE = 10;
 
+let panelId = 0;
+
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-interface PanelOptions {
-  minSize: () => number | undefined;
-  maxSize: () => number | undefined;
-  defaultSize: () => number | undefined;
-  collapsible: () => boolean | undefined;
+function numberAttribute(element: Element, name: string): number | undefined {
+  const raw = element.getAttribute(name);
+
+  if (raw === null) return undefined;
+
+  const value = parseFloat(raw);
+
+  return Number.isFinite(value) ? value : undefined;
 }
 
-export class PanelState {
-  /**
-   * The panel's current size, as a percentage of the group's panel-space
-   * (the group's size minus the space occupied by the handles).
-   *
-   * `null` until the group has performed its first layout.
-   */
-  @tracked size: number | null = null;
+/**
+ * Panels declare their constraints in the DOM (via data attributes),
+ * so the group can discover everything it needs with queries --
+ * no registration required.
+ */
+function minSizeOf(panel: Element): number {
+  return numberAttribute(panel, 'data-min-size') ?? DEFAULT_MIN;
+}
 
-  /**
-   * The size (%) this panel had before it was collapsed,
-   * so that expanding restores it.
-   */
-  previousSize: number | null = null;
+function maxSizeOf(panel: Element): number {
+  return numberAttribute(panel, 'data-max-size') ?? DEFAULT_MAX;
+}
 
-  element: HTMLElement | null = null;
+function requestedSizeOf(panel: Element): number | undefined {
+  return numberAttribute(panel, 'data-size');
+}
 
-  #options: PanelOptions;
-
-  constructor(options: PanelOptions) {
-    this.#options = options;
-  }
-
-  get id(): string {
-    return guidFor(this);
-  }
-
-  get minSize(): number {
-    return this.#options.minSize() ?? DEFAULT_MIN;
-  }
-
-  get maxSize(): number {
-    return this.#options.maxSize() ?? DEFAULT_MAX;
-  }
-
-  get defaultSize(): number | undefined {
-    return this.#options.defaultSize();
-  }
-
-  get collapsible(): boolean {
-    return this.#options.collapsible() ?? false;
-  }
-
-  get isCollapsed(): boolean {
-    return this.collapsible && this.size !== null && this.size <= COLLAPSED_EPSILON;
-  }
-
-  /**
-   * Percentage-based flex-grow keeps sizing proportional without
-   * needing to measure anything during render.
-   */
-  get style(): StyleString {
-    if (this.size === null) {
-      return htmlSafe(`flex: 1 1 0px;`);
-    }
-
-    return htmlSafe(`flex: ${this.size} 1 0px;`);
-  }
+function isCollapsible(panel: Element): boolean {
+  return panel.hasAttribute('data-collapsible');
 }
 
 interface DragState {
-  prev: PanelState;
-  next: PanelState;
+  prev: HTMLElement;
+  next: HTMLElement;
   startPrevSize: number;
   startNextSize: number;
   startCoordinate: number;
@@ -119,15 +72,24 @@ interface GroupOptions {
 }
 
 export class GroupState {
-  /**
-   * Panels in document order. Only assigned during the scheduled sync,
-   * never during render (avoids backtracking re-render assertions).
-   */
-  @tracked panels: PanelState[] = [];
+  element: HTMLElement | null = null;
 
-  #registered: PanelState[] = [];
   #options: GroupOptions;
+  #observer: MutationObserver | null = null;
   #drag: DragState | null = null;
+
+  /**
+   * Current size (%) per panel element.
+   * The DOM is the source of truth for membership; this only remembers
+   * sizes across relayouts.
+   */
+  #sizes = new Map<HTMLElement, number>();
+
+  /**
+   * The size (%) a collapsible panel had before it was collapsed,
+   * so that expanding restores it.
+   */
+  #previousSizes = new WeakMap<HTMLElement, number>();
 
   constructor(options: GroupOptions) {
     this.#options = options;
@@ -141,77 +103,111 @@ export class GroupState {
     return this.orientation === 'horizontal';
   }
 
+  /**
+   * This group's panels, in document order.
+   * Panels of nested groups belong to their own group, not this one.
+   */
+  get panels(): HTMLElement[] {
+    return this.#query(PANEL_SELECTOR);
+  }
+
+  get handles(): HTMLElement[] {
+    return this.#query(HANDLE_SELECTOR);
+  }
+
+  #query(selector: string): HTMLElement[] {
+    const element = this.element;
+
+    if (!element) return [];
+
+    const all = Array.from(element.querySelectorAll<HTMLElement>(selector));
+
+    return all.filter((candidate) => candidate.closest(GROUP_SELECTOR) === element);
+  }
+
   get sizes(): number[] {
-    return this.panels.map((panel) => panel.size ?? 0);
-  }
-
-  registerPanel(panel: PanelState): void {
-    this.#registered.push(panel);
-    this.#scheduleSync();
-  }
-
-  unregisterPanel(panel: PanelState): void {
-    this.#registered = this.#registered.filter((existing) => existing !== panel);
-    this.#scheduleSync();
-  }
-
-  #scheduleSync(): void {
-    // eslint-disable-next-line ember/no-runloop
-    scheduleOnce('afterRender', this, this.#sync);
+    return this.panels.map((panel) => this.#sizes.get(panel) ?? 0);
   }
 
   /**
-   * Commits registration changes and (re)computes the layout.
-   * Runs after render so that tracked state consumed by sibling panels
-   * is never written to mid-render.
+   * Called (via modifier) when the group element is inserted.
+   * Watches for panels being added/removed (and the orientation
+   * changing) and performs the initial layout.
    */
-  #sync = (): void => {
-    const connected = this.#registered.filter((panel) => panel.element?.isConnected);
+  attach = (element: HTMLElement): (() => void) => {
+    this.element = element;
 
-    connected.sort((a, b) => {
-      if (!a.element || !b.element) return 0;
-
-      /**
-       * a.element precedes b.element => bitmask includes "preceding" from b's perspective
-       */
-      const position = b.element.compareDocumentPosition(a.element);
-
-      return position & Node.DOCUMENT_POSITION_PRECEDING ? -1 : 1;
+    this.#observer = new MutationObserver((mutations) => this.#onMutation(mutations));
+    this.#observer.observe(element, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['data-orientation'],
     });
 
-    this.panels = connected;
     this.#layout();
+
+    return () => {
+      this.#observer?.disconnect();
+      this.#observer = null;
+      this.element = null;
+    };
   };
 
+  #onMutation(mutations: MutationRecord[]): void {
+    const relevant = mutations.some((mutation) => {
+      const target = mutation.target;
+
+      if (!(target instanceof Element)) return false;
+
+      // the orientation of this group changed
+      if (mutation.type === 'attributes') return target === this.element;
+
+      // children changed somewhere that belongs to this group (not a nested one)
+      return target.closest(GROUP_SELECTOR) === this.element;
+    });
+
+    if (relevant) this.#layout();
+  }
+
   /**
-   * Panels that already have a size (or declare a defaultSize) keep it,
-   * new panels take an equal share, then everything is normalized to 100.
+   * Panels that already have a size (or request one via `data-size`)
+   * keep it; new panels take a share of the remaining space; everything
+   * is normalized to 100.
    */
   #layout(): void {
     const panels = this.panels;
 
     if (panels.length === 0) return;
 
-    const specified: PanelState[] = [];
-    const unspecified: PanelState[] = [];
+    // forget sizes of panels that left the DOM
+    for (const known of Array.from(this.#sizes.keys())) {
+      if (!panels.includes(known)) this.#sizes.delete(known);
+    }
+
+    const next = new Map<HTMLElement, number>();
+    const unspecified: HTMLElement[] = [];
     let specifiedTotal = 0;
 
     for (const panel of panels) {
-      const preferred = panel.size ?? panel.defaultSize;
+      const preferred = this.#sizes.get(panel) ?? requestedSizeOf(panel);
 
       if (preferred === undefined) {
         unspecified.push(panel);
         continue;
       }
 
-      panel.size = panel.isCollapsed ? panel.size : clamp(preferred, panel.minSize, panel.maxSize);
-      specified.push(panel);
-      specifiedTotal += panel.size ?? 0;
+      const size = this.#isCollapsed(panel)
+        ? preferred
+        : clamp(preferred, minSizeOf(panel), maxSizeOf(panel));
+
+      next.set(panel, size);
+      specifiedTotal += size;
     }
 
     if (unspecified.length > 0) {
       /**
-       * Panels without a (default)size share the remaining space.
+       * Panels without a size share the remaining space.
        * When there is none left (e.g. a panel was added to an
        * already-full group), each takes an equal 1/n share and the
        * existing panels scale down to make room -- like a new window
@@ -226,29 +222,67 @@ export class GroupState {
         if (specifiedTotal > 0) {
           const scale = Math.max(100 - share * unspecified.length, 0) / specifiedTotal;
 
-          for (const panel of specified) {
-            panel.size = (panel.size ?? 0) * scale;
+          for (const [panel, size] of next) {
+            next.set(panel, size * scale);
           }
         }
       }
 
       for (const panel of unspecified) {
-        panel.size = clamp(share, panel.minSize, panel.maxSize);
+        next.set(panel, clamp(share, minSizeOf(panel), maxSizeOf(panel)));
       }
     }
 
-    this.#normalize();
+    // normalize to 100
+    let total = 0;
+
+    for (const size of next.values()) total += size;
+
+    if (total > 0 && Math.abs(total - 100) > 0.01) {
+      for (const [panel, size] of next) {
+        next.set(panel, (size / total) * 100);
+      }
+    }
+
+    this.#sizes = next;
+    this.#apply();
     this.#notify();
   }
 
-  #normalize(): void {
-    const panels = this.panels;
-    const total = panels.reduce((sum, panel) => sum + (panel.size ?? 0), 0);
+  /**
+   * Writes the layout back to the DOM: flex sizing and the handles'
+   * ARIA attributes. (`data-collapsed` is managed at the explicit
+   * collapse/expand points, not derived from sizes -- rendered pixel
+   * sizes include borders/padding, so a collapsed panel rarely
+   * measures exactly 0.)
+   */
+  #apply(): void {
+    for (const [panel, size] of this.#sizes) {
+      panel.style.flex = `${size} 1 0px`;
+    }
 
-    if (total <= 0 || Math.abs(total - 100) < 0.01) return;
+    this.#syncHandles();
+  }
 
-    for (const panel of panels) {
-      panel.size = ((panel.size ?? 0) / total) * 100;
+  /**
+   * Per the window-splitter pattern, each handle describes the panel
+   * immediately before it. (A splitter between two side-by-side panes
+   * is oriented *vertically*, and vice-versa.)
+   */
+  #syncHandles(): void {
+    for (const handle of this.handles) {
+      const [prev] = this.#neighborsOf(handle);
+
+      handle.setAttribute('aria-orientation', this.#isHorizontal ? 'vertical' : 'horizontal');
+
+      if (!prev) continue;
+
+      if (!prev.id) prev.id = `ember-primitives__resizable__panel--${panelId++}`;
+
+      handle.setAttribute('aria-controls', prev.id);
+      handle.setAttribute('aria-valuemin', `${minSizeOf(prev)}`);
+      handle.setAttribute('aria-valuemax', `${maxSizeOf(prev)}`);
+      handle.setAttribute('aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);
     }
   }
 
@@ -257,25 +291,40 @@ export class GroupState {
   }
 
   /**
+   * The `data-collapsed` attribute is the source of truth for collapse
+   * state (it is also the styling hook consumers use).
+   */
+  #isCollapsed(panel: HTMLElement): boolean {
+    return isCollapsible(panel) && panel.hasAttribute('data-collapsed');
+  }
+
+  #setCollapsed(panel: HTMLElement, collapsed: boolean): void {
+    if (collapsed) {
+      panel.setAttribute('data-collapsed', '');
+    } else {
+      panel.removeAttribute('data-collapsed');
+    }
+  }
+
+  /**
    * Re-derive percentage sizes from actual rendered pixels.
    * Corrects any drift (e.g. from CSS min-sizes) before an interaction.
    */
   #syncSizesFromDOM(): void {
     const panels = this.panels;
-    const px = panels.map((panel) => this.#pixelSizeOf(panel));
+    // collapsed panels are 0 even though their borders/padding measure larger
+    const px = panels.map((panel) => (this.#isCollapsed(panel) ? 0 : this.#pixelSizeOf(panel)));
     const total = px.reduce((sum, value) => sum + value, 0);
 
     if (total <= 0) return;
 
     panels.forEach((panel, index) => {
-      panel.size = ((px[index] ?? 0) / total) * 100;
+      this.#sizes.set(panel, ((px[index] ?? 0) / total) * 100);
     });
   }
 
-  #pixelSizeOf(panel: PanelState): number {
-    const box = panel.element?.getBoundingClientRect();
-
-    if (!box) return 0;
+  #pixelSizeOf(panel: HTMLElement): number {
+    const box = panel.getBoundingClientRect();
 
     return this.#isHorizontal ? box.width : box.height;
   }
@@ -284,14 +333,12 @@ export class GroupState {
    * The panels immediately before and after the given handle element,
    * in document order.
    */
-  neighborsOf(handleElement: HTMLElement): [PanelState | null, PanelState | null] {
-    let prev: PanelState | null = null;
-    let next: PanelState | null = null;
+  #neighborsOf(handleElement: HTMLElement): [HTMLElement | null, HTMLElement | null] {
+    let prev: HTMLElement | null = null;
+    let next: HTMLElement | null = null;
 
     for (const panel of this.panels) {
-      if (!panel.element) continue;
-
-      const position = handleElement.compareDocumentPosition(panel.element);
+      const position = handleElement.compareDocumentPosition(panel);
 
       if (position & Node.DOCUMENT_POSITION_PRECEDING) {
         prev = panel;
@@ -310,8 +357,8 @@ export class GroupState {
    * respecting both panels' min/max constraints.
    */
   #applyDelta(
-    prev: PanelState,
-    next: PanelState,
+    prev: HTMLElement,
+    next: HTMLElement,
     basePrevSize: number,
     baseNextSize: number,
     requestedDelta: number
@@ -320,35 +367,44 @@ export class GroupState {
 
     let target = basePrevSize + requestedDelta;
 
-    if (prev.collapsible && target < prev.minSize) {
+    if (isCollapsible(prev) && target < minSizeOf(prev)) {
       /**
        * Collapsible panels snap: below half the minimum they close
        * entirely; between half and the minimum they hold at the minimum.
        * (This also keeps a collapsed panel closed when its handle is
        * dragged further in the closing direction.)
        */
-      target = target < prev.minSize / 2 ? 0 : prev.minSize;
+      target = target < minSizeOf(prev) / 2 ? 0 : minSizeOf(prev);
     } else {
-      target = clamp(target, prev.minSize, prev.maxSize);
+      target = clamp(target, minSizeOf(prev), maxSizeOf(prev));
     }
 
     /**
      * The neighbor absorbs whatever the target panel gives or takes,
      * so its constraints bound the target too.
      */
-    const nextMin = total - next.maxSize;
-    const nextMax = total - next.minSize;
+    const nextMin = total - maxSizeOf(next);
+    const nextMax = total - minSizeOf(next);
 
     if (nextMin > nextMax) return;
 
     target = clamp(target, nextMin, nextMax);
 
     // both panels' constraints cannot be satisfied at once
-    if (!prev.collapsible && (target < prev.minSize || target > prev.maxSize)) return;
+    if (!isCollapsible(prev) && (target < minSizeOf(prev) || target > maxSizeOf(prev))) return;
 
-    prev.size = target;
-    next.size = total - target;
+    if (isCollapsible(prev)) {
+      if (target === 0 && !this.#isCollapsed(prev)) {
+        this.#previousSizes.set(prev, basePrevSize);
+      }
 
+      this.#setCollapsed(prev, target === 0);
+    }
+
+    this.#sizes.set(prev, target);
+    this.#sizes.set(next, total - target);
+
+    this.#apply();
     this.#notify();
   }
 
@@ -356,7 +412,7 @@ export class GroupState {
     if (event.button !== 0) return;
     if (this.#drag) return;
 
-    const [prev, next] = this.neighborsOf(handleElement);
+    const [prev, next] = this.#neighborsOf(handleElement);
 
     if (!prev || !next) return;
 
@@ -368,8 +424,8 @@ export class GroupState {
     this.#drag = {
       prev,
       next,
-      startPrevSize: prev.size ?? 0,
-      startNextSize: next.size ?? 0,
+      startPrevSize: this.#sizes.get(prev) ?? 0,
+      startNextSize: this.#sizes.get(next) ?? 0,
       startCoordinate: this.#isHorizontal ? event.clientX : event.clientY,
       totalPx: this.panels.reduce((sum, panel) => sum + this.#pixelSizeOf(panel), 0),
       move,
@@ -433,12 +489,12 @@ export class GroupState {
    * Keyboard support for the WAI-ARIA window-splitter pattern.
    */
   handleKeyDown(handleElement: HTMLElement, event: KeyboardEvent): void {
-    const [prev, next] = this.neighborsOf(handleElement);
+    const [prev, next] = this.#neighborsOf(handleElement);
 
     if (!prev || !next) return;
 
     if (event.key === 'Enter') {
-      this.toggleCollapse(handleElement);
+      this.#toggleCollapse(prev, next);
 
       return;
     }
@@ -467,12 +523,12 @@ export class GroupState {
         break;
       case 'Home':
         this.#syncSizesFromDOM();
-        delta = prev.minSize - (prev.size ?? 0);
+        delta = minSizeOf(prev) - (this.#sizes.get(prev) ?? 0);
 
         break;
       case 'End':
         this.#syncSizesFromDOM();
-        delta = prev.maxSize - (prev.size ?? 0);
+        delta = maxSizeOf(prev) - (this.#sizes.get(prev) ?? 0);
 
         break;
     }
@@ -482,7 +538,7 @@ export class GroupState {
     event.preventDefault();
 
     this.#syncSizesFromDOM();
-    this.#applyDelta(prev, next, prev.size ?? 0, next.size ?? 0, delta);
+    this.#applyDelta(prev, next, this.#sizes.get(prev) ?? 0, this.#sizes.get(next) ?? 0, delta);
   }
 
   /**
@@ -491,78 +547,33 @@ export class GroupState {
    *
    * Only does anything when the preceding panel is `@collapsible`.
    */
-  toggleCollapse(handleElement: HTMLElement): void {
-    const [prev, next] = this.neighborsOf(handleElement);
-
-    if (!prev || !next) return;
-    if (!prev.collapsible) return;
+  #toggleCollapse(prev: HTMLElement, next: HTMLElement): void {
+    if (!isCollapsible(prev)) return;
 
     this.#syncSizesFromDOM();
 
-    const prevSize = prev.size ?? 0;
-    const nextSize = next.size ?? 0;
+    const prevSize = this.#sizes.get(prev) ?? 0;
+    const nextSize = this.#sizes.get(next) ?? 0;
 
-    if (prev.isCollapsed) {
-      const preferred = prev.previousSize ?? prev.defaultSize ?? Math.max(prev.minSize, 10);
-      const available = nextSize - next.minSize;
+    if (this.#isCollapsed(prev)) {
+      const preferred =
+        this.#previousSizes.get(prev) ?? requestedSizeOf(prev) ?? Math.max(minSizeOf(prev), 10);
+      const available = nextSize - minSizeOf(next);
       const restored = Math.min(preferred, available);
 
       if (restored <= 0) return;
 
-      prev.size = restored;
-      next.size = nextSize - restored;
+      this.#setCollapsed(prev, false);
+      this.#sizes.set(prev, restored);
+      this.#sizes.set(next, nextSize - restored);
     } else {
-      prev.previousSize = prevSize;
-      prev.size = 0;
-      next.size = nextSize + prevSize;
+      this.#previousSizes.set(prev, prevSize);
+      this.#setCollapsed(prev, true);
+      this.#sizes.set(prev, 0);
+      this.#sizes.set(next, nextSize + prevSize);
     }
 
+    this.#apply();
     this.#notify();
-  }
-}
-
-export class HandleState {
-  @tracked element: HTMLElement | null = null;
-
-  #group: GroupState;
-
-  constructor(group: GroupState) {
-    this.#group = group;
-  }
-
-  get #neighbors(): [PanelState | null, PanelState | null] {
-    if (!this.element) return [null, null];
-
-    return this.#group.neighborsOf(this.element);
-  }
-
-  get #prevPanel(): PanelState | null {
-    return this.#neighbors[0];
-  }
-
-  /**
-   * Per the window-splitter pattern, a splitter between two side-by-side
-   * panes is oriented *vertically* (and vice-versa).
-   */
-  get ariaOrientation(): Orientation {
-    return this.#group.orientation === 'horizontal' ? 'vertical' : 'horizontal';
-  }
-
-  get valueNow(): number | undefined {
-    const size = this.#prevPanel?.size;
-
-    return size === null || size === undefined ? undefined : Math.round(size);
-  }
-
-  get valueMin(): number | undefined {
-    return this.#prevPanel?.minSize;
-  }
-
-  get valueMax(): number | undefined {
-    return this.#prevPanel?.maxSize;
-  }
-
-  get controls(): string | undefined {
-    return this.#prevPanel?.id;
   }
 }

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -106,7 +106,6 @@ export class GroupState {
   element: HTMLElement | null = null;
 
   #options: GroupOptions;
-  #observer: MutationObserver | null = null;
   #drag: DragState | null = null;
 
   /**
@@ -129,6 +128,18 @@ export class GroupState {
    */
   #knownPanels: HTMLElement[] = [];
   #knownHandles: HTMLElement[] = [];
+
+  /**
+   * The percentage that a flex-grow of 1 represents in this group.
+   *
+   * Panels without an inline style render at the CSS default
+   * (`flex: 1 1 0px`), so an all-equal group needs no styles at all --
+   * mounting one writes nothing. The unit is fixed the first time a
+   * panel actually diverges, and from then on grow values are written
+   * relative to it, so panels whose share doesn't change keep their
+   * (possibly absent) style untouched.
+   */
+  #unit: number | null = null;
 
   constructor(options: GroupOptions) {
     this.#options = options;
@@ -169,6 +180,83 @@ export class GroupState {
   }
 
   /**
+   * One MutationObserver for every group on the page. Each record is
+   * routed to the group that owns it (the nearest group ancestor), so
+   * churn inside a nested group never even pings its ancestors.
+   */
+  static #observed = new Map<HTMLElement, GroupState>();
+  static #observer: MutationObserver | null = null;
+
+  static #observerOptions: MutationObserverInit = {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['data-orientation'],
+  };
+
+  static #handleMutations(mutations: MutationRecord[]): void {
+    /**
+     * true = the group's own data-orientation changed,
+     * false = something in its subtree changed (membership check needed)
+     */
+    const affected = new Map<GroupState, boolean>();
+
+    for (const mutation of mutations) {
+      const target = mutation.target;
+
+      if (!(target instanceof Element)) continue;
+
+      if (mutation.type === 'attributes') {
+        const group = GroupState.#observed.get(target as HTMLElement);
+
+        if (group) affected.set(group, true);
+        continue;
+      }
+
+      const groupElement = target.closest<HTMLElement>(GROUP_SELECTOR);
+      const group = groupElement && GroupState.#observed.get(groupElement);
+
+      if (group && !affected.has(group)) affected.set(group, false);
+    }
+
+    for (const [group, orientationChanged] of affected) {
+      if (orientationChanged || group.#membershipChanged()) group.#layout();
+    }
+  }
+
+  static #observe(element: HTMLElement, group: GroupState): void {
+    GroupState.#observed.set(element, group);
+    GroupState.#observer ??= new MutationObserver((mutations) =>
+      GroupState.#handleMutations(mutations)
+    );
+    GroupState.#observer.observe(element, GroupState.#observerOptions);
+  }
+
+  static #unobserve(element: HTMLElement): void {
+    GroupState.#observed.delete(element);
+
+    const observer = GroupState.#observer;
+
+    if (!observer) return;
+
+    /**
+     * MutationObserver has no per-target unobserve; disconnect and
+     * re-observe the remaining groups (rare -- teardown only).
+     */
+    observer.disconnect();
+
+    if (GroupState.#observed.size === 0) {
+      GroupState.#observer = null;
+
+      return;
+    }
+
+    for (const remaining of GroupState.#observed.keys()) {
+      observer.observe(remaining, GroupState.#observerOptions);
+    }
+  }
+
+  /**
    * Called (via modifier) when the group element is inserted.
    * Watches for panels being added/removed (and the orientation
    * changing) and performs the initial layout.
@@ -176,38 +264,15 @@ export class GroupState {
   attach = (element: HTMLElement): (() => void) => {
     this.element = element;
 
-    this.#observer = new MutationObserver((mutations) => this.#onMutation(mutations));
-    this.#observer.observe(element, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      attributeFilter: ['data-orientation'],
-    });
+    GroupState.#observe(element, this);
 
     this.#layout();
 
     return () => {
-      this.#observer?.disconnect();
-      this.#observer = null;
+      GroupState.#unobserve(element);
       this.element = null;
     };
   };
-
-  /**
-   * Subtree observation is required (panels may sit behind wrapper
-   * elements), which means this also fires for churn inside nested
-   * groups and for content changes within panels. Rather than
-   * classifying every mutation, we answer the only question that
-   * matters -- did *this* group's membership actually change? --
-   * and no-op otherwise.
-   */
-  #onMutation(mutations: MutationRecord[]): void {
-    const orientationChanged = mutations.some(
-      (mutation) => mutation.type === 'attributes' && mutation.target === this.element
-    );
-
-    if (orientationChanged || this.#membershipChanged()) this.#layout();
-  }
 
   #membershipChanged(): boolean {
     return (
@@ -322,18 +387,32 @@ export class GroupState {
 
   /**
    * Writes the layout back to the DOM: flex sizing for exactly the
-   * panels that changed, plus the handles' ARIA attributes (which are
-   * guarded per-attribute). (`data-collapsed` is managed at the
-   * explicit collapse/expand points, not derived from sizes --
-   * rendered pixel sizes include borders/padding, so a collapsed
-   * panel rarely measures exactly 0.)
+   * candidate panels whose rendered share would actually change, plus
+   * the handles' ARIA attributes (which are guarded per-attribute).
+   * (`data-collapsed` is managed at the explicit collapse/expand
+   * points, not derived from sizes -- rendered pixel sizes include
+   * borders/padding, so a collapsed panel rarely measures exactly 0.)
    */
-  #apply(changedPanels: HTMLElement[]): void {
-    for (const panel of changedPanels) {
-      const size = this.#sizes.get(panel);
+  #apply(candidates: HTMLElement[]): void {
+    if (candidates.length > 0) {
+      /**
+       * With no unit fixed yet, nothing has ever been written, so every
+       * panel renders at the CSS default -- an equal 1/n share.
+       */
+      const unit = this.#unit ?? 100 / this.panels.length;
 
-      if (size !== undefined) {
-        panel.style.flex = `${size} 1 0px`;
+      for (const panel of candidates) {
+        const size = this.#sizes.get(panel);
+
+        if (size === undefined) continue;
+
+        const inlineGrow = panel.style.flexGrow;
+        const impliedPercent = (inlineGrow === '' ? 1 : parseFloat(inlineGrow)) * unit;
+
+        if (isSameSize(impliedPercent, size)) continue;
+
+        this.#unit ??= unit;
+        panel.style.flex = `${size / unit} 1 0px`;
       }
     }
 

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -432,6 +432,7 @@ export class GroupState {
 
       if (!prev) continue;
 
+      // Panels render their own id; this only fires for hand-written markup
       if (!prev.id) prev.id = `ember-primitives__resizable__panel--${panelId++}`;
 
       setAttribute(handle, 'aria-controls', prev.id);

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -51,6 +51,20 @@ function isCollapsible(panel: Element): boolean {
   return panel.hasAttribute('data-collapsible');
 }
 
+function sameMembers(a: HTMLElement[], b: HTMLElement[]): boolean {
+  return a.length === b.length && a.every((element, index) => element === b[index]);
+}
+
+/**
+ * Skips the write when the attribute already has the desired value,
+ * so unchanged elements are left untouched.
+ */
+function setAttribute(element: Element, name: string, value: string): void {
+  if (element.getAttribute(name) !== value) {
+    element.setAttribute(name, value);
+  }
+}
+
 interface DragState {
   prev: HTMLElement;
   next: HTMLElement;
@@ -90,6 +104,14 @@ export class GroupState {
    * so that expanding restores it.
    */
   #previousSizes = new WeakMap<HTMLElement, number>();
+
+  /**
+   * Membership as of the last layout, so mutation batches that don't
+   * change membership (e.g. content changes inside a panel, or churn
+   * within a nested group) can be ignored.
+   */
+  #knownPanels: HTMLElement[] = [];
+  #knownHandles: HTMLElement[] = [];
 
   constructor(options: GroupOptions) {
     this.#options = options;
@@ -154,20 +176,26 @@ export class GroupState {
     };
   };
 
+  /**
+   * Subtree observation is required (panels may sit behind wrapper
+   * elements), which means this also fires for churn inside nested
+   * groups and for content changes within panels. Rather than
+   * classifying every mutation, we answer the only question that
+   * matters -- did *this* group's membership actually change? --
+   * and no-op otherwise.
+   */
   #onMutation(mutations: MutationRecord[]): void {
-    const relevant = mutations.some((mutation) => {
-      const target = mutation.target;
+    const orientationChanged = mutations.some(
+      (mutation) => mutation.type === 'attributes' && mutation.target === this.element
+    );
 
-      if (!(target instanceof Element)) return false;
+    if (orientationChanged || this.#membershipChanged()) this.#layout();
+  }
 
-      // the orientation of this group changed
-      if (mutation.type === 'attributes') return target === this.element;
-
-      // children changed somewhere that belongs to this group (not a nested one)
-      return target.closest(GROUP_SELECTOR) === this.element;
-    });
-
-    if (relevant) this.#layout();
+  #membershipChanged(): boolean {
+    return (
+      !sameMembers(this.panels, this.#knownPanels) || !sameMembers(this.handles, this.#knownHandles)
+    );
   }
 
   /**
@@ -177,6 +205,9 @@ export class GroupState {
    */
   #layout(): void {
     const panels = this.panels;
+
+    this.#knownPanels = panels;
+    this.#knownHandles = this.handles;
 
     if (panels.length === 0) return;
 
@@ -258,7 +289,11 @@ export class GroupState {
    */
   #apply(): void {
     for (const [panel, size] of this.#sizes) {
-      panel.style.flex = `${size} 1 0px`;
+      const flex = `${size} 1 0px`;
+
+      if (panel.style.flex !== flex) {
+        panel.style.flex = flex;
+      }
     }
 
     this.#syncHandles();
@@ -273,16 +308,16 @@ export class GroupState {
     for (const handle of this.handles) {
       const [prev] = this.#neighborsOf(handle);
 
-      handle.setAttribute('aria-orientation', this.#isHorizontal ? 'vertical' : 'horizontal');
+      setAttribute(handle, 'aria-orientation', this.#isHorizontal ? 'vertical' : 'horizontal');
 
       if (!prev) continue;
 
       if (!prev.id) prev.id = `ember-primitives__resizable__panel--${panelId++}`;
 
-      handle.setAttribute('aria-controls', prev.id);
-      handle.setAttribute('aria-valuemin', `${minSizeOf(prev)}`);
-      handle.setAttribute('aria-valuemax', `${maxSizeOf(prev)}`);
-      handle.setAttribute('aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);
+      setAttribute(handle, 'aria-controls', prev.id);
+      setAttribute(handle, 'aria-valuemin', `${minSizeOf(prev)}`);
+      setAttribute(handle, 'aria-valuemax', `${maxSizeOf(prev)}`);
+      setAttribute(handle, 'aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);
     }
   }
 

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -430,12 +430,6 @@ export class GroupState {
 
       if (!prev) continue;
 
-      /**
-       * ids are global, so we never generate one -- but when the
-       * consumer gave their panel an id, the handle references it.
-       */
-      if (prev.id) setAttribute(handle, 'aria-controls', prev.id);
-
       setAttribute(handle, 'aria-valuemin', `${minSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuemax', `${maxSizeOf(prev)}`);
       setAttribute(handle, 'aria-valuenow', `${Math.round(this.#sizes.get(prev) ?? 0)}`);

--- a/ember-primitives/src/components/resizable/state.ts
+++ b/ember-primitives/src/components/resizable/state.ts
@@ -56,6 +56,14 @@ function sameMembers(a: HTMLElement[], b: HTMLElement[]): boolean {
 }
 
 /**
+ * Sizes are floats that get re-derived (measurement, normalization),
+ * so "unchanged" means within a small tolerance.
+ */
+function isSameSize(existing: number | undefined, size: number): boolean {
+  return existing !== undefined && Math.abs(existing - size) < 0.0001;
+}
+
+/**
  * Skips the write when the attribute already has the desired value,
  * so unchanged elements are left untouched.
  */
@@ -205,9 +213,10 @@ export class GroupState {
    */
   #layout(): void {
     const panels = this.panels;
+    const handles = this.handles;
 
-    this.#knownPanels = panels;
-    this.#knownHandles = this.handles;
+    if (!sameMembers(panels, this.#knownPanels)) this.#knownPanels = panels;
+    if (!sameMembers(handles, this.#knownHandles)) this.#knownHandles = handles;
 
     if (panels.length === 0) return;
 
@@ -288,9 +297,7 @@ export class GroupState {
      * from re-normalizing doesn't count as a change).
      */
     for (const [panel, size] of computed) {
-      const existing = this.#sizes.get(panel);
-
-      if (existing === undefined || Math.abs(existing - size) > 0.0001) {
+      if (!isSameSize(this.#sizes.get(panel), size)) {
         this.#sizes.set(panel, size);
         changed = true;
       }
@@ -355,6 +362,8 @@ export class GroupState {
   }
 
   #setCollapsed(panel: HTMLElement, collapsed: boolean): void {
+    if (collapsed === panel.hasAttribute('data-collapsed')) return;
+
     if (collapsed) {
       panel.setAttribute('data-collapsed', '');
     } else {
@@ -375,7 +384,11 @@ export class GroupState {
     if (total <= 0) return;
 
     panels.forEach((panel, index) => {
-      this.#sizes.set(panel, ((px[index] ?? 0) / total) * 100);
+      const size = ((px[index] ?? 0) / total) * 100;
+
+      if (!isSameSize(this.#sizes.get(panel), size)) {
+        this.#sizes.set(panel, size);
+      }
     });
   }
 
@@ -448,6 +461,17 @@ export class GroupState {
 
     // both panels' constraints cannot be satisfied at once
     if (!isCollapsible(prev) && (target < minSizeOf(prev) || target > maxSizeOf(prev))) return;
+
+    /**
+     * Nothing to do when the clamped result matches the current sizes
+     * (e.g. every pointermove past a min/max limit).
+     */
+    if (
+      isSameSize(this.#sizes.get(prev), target) &&
+      isSameSize(this.#sizes.get(next), total - target)
+    ) {
+      return;
+    }
 
     if (isCollapsible(prev)) {
       if (target === 0 && !this.#isCollapsed(prev)) {

--- a/ember-primitives/src/dom-context.gts
+++ b/ember-primitives/src/dom-context.gts
@@ -41,13 +41,16 @@ export class Provide<Data extends object> extends Component<{
     data: Data | (() => Data) | Newable<Data>;
 
     /**
-     * Optionally, you may use string-based keys to reference the data in the Provide.
+     * Optionally, you may use keys to reference the data in the Provide,
+     * e.g. when `@data` is an already-created instance and consumers
+     * reference it by its class.
      *
-     * This is not recommended though, because when using a class or other object-like structure,
+     * Keys are compared by identity. String keys are not recommended,
+     * because when using a class or other object-like structure,
      * the type in the `<Consume>` component can be derived from that class or object-like structure.
      * With string keys, the `<Consume>` type will be unknown.
      */
-    key?: string;
+    key?: string | object;
 
     /**
      * Can be used to either customize the element tag ( defaults to div )

--- a/ember-primitives/src/index.ts
+++ b/ember-primitives/src/index.ts
@@ -36,7 +36,11 @@ export { PortalTargets } from './components/portal-targets.gts';
 export { TARGETS as PORTALS } from './components/portal-targets.gts';
 export { Progress } from './components/progress.gts';
 export { Rating } from './components/rating.gts';
-export { Resizable } from './components/resizable.gts';
+export {
+  Resizable,
+  Handle as ResizableHandle,
+  Panel as ResizablePanel,
+} from './components/resizable.gts';
 export { Scroller } from './components/scroller.gts';
 export { Separator } from './components/separator.gts';
 export { Shadowed } from './components/shadowed.gts';

--- a/ember-primitives/src/index.ts
+++ b/ember-primitives/src/index.ts
@@ -36,6 +36,7 @@ export { PortalTargets } from './components/portal-targets.gts';
 export { TARGETS as PORTALS } from './components/portal-targets.gts';
 export { Progress } from './components/progress.gts';
 export { Rating } from './components/rating.gts';
+export { Resizable } from './components/resizable.gts';
 export { Scroller } from './components/scroller.gts';
 export { Separator } from './components/separator.gts';
 export { Shadowed } from './components/shadowed.gts';

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
       "ember-element-helper": "^0.8.8",
       "ember-primitives": "workspace:^",
       "ember-repl": "^8.0.0",
-      "ember-source": "^6.10.1",
+      "ember-source": "^7.1.0",
       "reactiveweb": "^1.9.1",
       "tracked-toolbox": "^3.0.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ overrides:
   ember-element-helper: ^0.8.8
   ember-primitives: workspace:^
   ember-repl: ^8.0.0
-  ember-source: ^6.10.1
+  ember-source: ^7.1.0
   reactiveweb: ^1.9.1
   tracked-toolbox: ^3.0.0
 
@@ -61,7 +61,7 @@ importers:
         version: 3.23.0
       '@universal-ember/docs-support':
         specifier: workspace:*
-        version: file:packages/docs-support(9ca6f02f8623dd825a3d0a90a5b42061)
+        version: file:packages/docs-support(44d57c380a15df4809fb9a178bbf4658)
       assert:
         specifier: ^2.0.0
         version: 2.1.0
@@ -79,7 +79,7 @@ importers:
         version: 2.0.0(@babel/core@7.29.0)
       ember-mobile-menu:
         specifier: ^6.0.0
-        version: 6.1.0(c0798c5eb304914fe7bcdcc185f995aa)
+        version: 6.1.0(f99eb3e0deb9fd5eb4258289317e9973)
       ember-modifier:
         specifier: ^4.3.0
         version: 4.3.0(@babel/core@7.29.0)
@@ -238,8 +238,8 @@ importers:
         specifier: ^2.0.4
         version: 2.2.2(ember-template-lint@7.9.3)
       ember-source:
-        specifier: ^6.10.1
-        version: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        specifier: ^7.1.0
+        version: 7.1.0(@glimmer/component@2.1.1)
       ember-template-lint:
         specifier: ^7.9.3
         version: 7.9.3
@@ -410,8 +410,8 @@ importers:
         specifier: ^7.0.7
         version: 7.0.7(2935cfb77147881c8250be8c1bb7d0d1)
       ember-source:
-        specifier: ^6.10.1
-        version: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        specifier: ^7.1.0
+        version: 7.1.0(@glimmer/component@2.1.1)
       ember-template-lint:
         specifier: ^7.9.3
         version: 7.9.3
@@ -462,7 +462,7 @@ importers:
         version: 2.3.2(@babel/core@7.29.0)
       ember-mobile-menu:
         specifier: ^6.0.0
-        version: 6.1.0(c0798c5eb304914fe7bcdcc185f995aa)
+        version: 6.1.0(f99eb3e0deb9fd5eb4258289317e9973)
       ember-modifier:
         specifier: ^4.3.0
         version: 4.3.0(@babel/core@7.29.0)
@@ -531,8 +531,8 @@ importers:
         specifier: ^2.0.4
         version: 2.2.2(ember-template-lint@7.9.3)
       ember-source:
-        specifier: ^6.10.1
-        version: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        specifier: ^7.1.0
+        version: 7.1.0(@glimmer/component@2.1.1)
       ember-template-lint:
         specifier: ^7.9.3
         version: 7.9.3
@@ -704,7 +704,7 @@ importers:
         version: 1.1.3
       ember-load-initializers:
         specifier: ^3.0.1
-        version: 3.0.1(6d319b1a0d9582607008b9b09e953766)
+        version: 3.0.1(b44793b7d4517f1faf6dca9cfb99f5ed)
       ember-modifier:
         specifier: ^4.3.0
         version: 4.3.0(@babel/core@7.29.0)
@@ -718,8 +718,8 @@ importers:
         specifier: ^13.1.1
         version: 13.2.0
       ember-source:
-        specifier: ^6.10.1
-        version: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+        specifier: ^7.1.0
+        version: 7.1.0(@glimmer/component@2.1.1)
       ember-source-channel-url:
         specifier: ^3.0.0
         version: 3.0.0(encoding@0.1.13)
@@ -1570,9 +1570,6 @@ packages:
 
   '@ember/app-tsconfig@2.0.0':
     resolution: {integrity: sha512-NmD1OZFtCF49k4WDaPdhGP4OKoRbPaXpTBO3AsJe0okIJeCVUiEiC8YUpfTJmld9EJOEa9mW/p0tJQS70GktOA==}
-
-  '@ember/edition-utils@1.2.0':
-    resolution: {integrity: sha512-VmVq/8saCaPdesQmftPqbFtxJWrzxNGSQ+e8x8LLe3Hjm36pJ04Q8LeORGZkAeOhldoUX9seLGmSaHeXkIqoog==}
 
   '@ember/library-tsconfig@2.0.0':
     resolution: {integrity: sha512-DTGt9TYZ3bhObUviQXx4C0v46oWM7HsRrUTbgONw2QBhJVHlmXA89uXenlvuqVrCQkA0g5kz7wwyOlcjIZ8h0w==}
@@ -3852,9 +3849,6 @@ packages:
   ember-cli-get-component-path-option@1.0.0:
     resolution: {integrity: sha512-k47TDwcJ2zPideBCZE8sCiShSxQSpebY2BHcX2DdipMmBox5gsfyVrbKJWIHeSTTKyEUgmBIvQkqTOozEziCZA==}
 
-  ember-cli-is-package-missing@1.0.0:
-    resolution: {integrity: sha512-9hEoZj6Au5onlSDdcoBqYEPT8ehlYntZPxH8pBKV0GO7LNel88otSAQsCfXvbi2eKE+MaSeLG/gNaCI5UdWm9g==}
-
   ember-cli-normalize-entity-name@1.0.0:
     resolution: {integrity: sha512-rF4P1rW2P1gVX1ynZYPmuIf7TnAFDiJmIUFI1Xz16VYykUAyiOCme0Y22LeZq8rTzwBMiwBwoE3RO4GYWehXZA==}
 
@@ -3909,7 +3903,7 @@ packages:
     resolution: {integrity: sha512-LY92LRkO+wDiqeIjni3IXn1xV8lIUJzIm7Ywh7+sGeKpxy2qBtSlnyyFIAxBjCfD1RrM3wGSh3WKA41y+LS5lw==}
     peerDependencies:
       '@ember/test-helpers': '>=3.0.0'
-      ember-source: ^6.10.1
+      ember-source: ^7.1.0
     peerDependenciesMeta:
       '@ember/test-helpers':
         optional: true
@@ -3918,7 +3912,7 @@ packages:
     resolution: {integrity: sha512-qV3vxJKw5+7TVDdtdLPy8PhVsh58MlK8jwzqh5xeOwJPNP7o0+BlhvwoIlLYTPzGaHdfjEIFCgVSyMRGd74E1g==}
     engines: {node: '>= 18.*'}
     peerDependencies:
-      ember-source: ^6.10.1
+      ember-source: ^7.1.0
 
   ember-mobile-menu@6.1.0:
     resolution: {integrity: sha512-GbQYyZ7ABVLzBJZunuINJFfyNr+ow9aSMaOJJkjIy3DnlE6+KfC6w3sovykaZEaOSAmTYuzRj6ST24RJgqXAeA==}
@@ -3999,8 +3993,8 @@ packages:
     engines: {node: 10.* || 12.* || >= 14}
     hasBin: true
 
-  ember-source@6.12.0:
-    resolution: {integrity: sha512-cApfEKxltl2VWt0o24XISsdkpyqqtT8wG0/EWokjeyqBPRCOIej2PMzRkLAu3A5AWpuWoJ//yq04mDix7axA7w==}
+  ember-source@7.1.0:
+    resolution: {integrity: sha512-qOHhTiVMeYcNp2UQKuAqsf33LKgNtzqvw46dQX5AqutTfXXPn4KYR0+aiGQdJaCuzs81nFvvTDJuHzELOZ5UBg==}
     engines: {node: '>= 20.19'}
     peerDependencies:
       '@glimmer/component': ^2.0.0
@@ -6582,13 +6576,6 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
-  router_js@8.0.6:
-    resolution: {integrity: sha512-AjGxRDIpTGoAG8admFmvP/cxn1AlwwuosCclMU4R5oGHGt7ER0XtB3l9O04ToBDdPe4ivM/YcLopgBEpJssJ/Q==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      route-recognizer: ^0.3.4
-      rsvp: ^4.8.5
-
   rrweb-cssom@0.7.1:
     resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
 
@@ -8777,8 +8764,6 @@ snapshots:
 
   '@ember/app-tsconfig@2.0.0': {}
 
-  '@ember/edition-utils@1.2.0': {}
-
   '@ember/library-tsconfig@2.0.0': {}
 
   '@ember/optional-features@3.0.0(@types/node@25.6.0)':
@@ -9535,7 +9520,7 @@ snapshots:
   '@npmcli/fs@1.1.1':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.4
+      semver: 7.8.5
 
   '@npmcli/git@6.0.3':
     dependencies:
@@ -9545,7 +9530,7 @@ snapshots:
       npm-pick-manifest: 10.0.0
       proc-log: 5.0.0
       promise-retry: 2.0.1
-      semver: 7.7.4
+      semver: 7.8.5
       which: 5.0.0
 
   '@npmcli/move-file@1.1.2':
@@ -9560,7 +9545,7 @@ snapshots:
       hosted-git-info: 8.1.0
       json-parse-even-better-errors: 4.0.0
       proc-log: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-license: 3.0.4
 
   '@npmcli/promise-spawn@8.0.3':
@@ -10132,13 +10117,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@universal-ember/docs-support@file:packages/docs-support(9ca6f02f8623dd825a3d0a90a5b42061)':
+  '@universal-ember/docs-support@file:packages/docs-support(44d57c380a15df4809fb9a178bbf4658)':
     dependencies:
       '@embroider/addon-shim': 1.10.3
       '@fontsource/lexend': 5.2.11
       change-case: 5.4.4
       decorator-transforms: 2.3.2(@babel/core@7.29.0)
-      ember-mobile-menu: 6.1.0(c0798c5eb304914fe7bcdcc185f995aa)
+      ember-mobile-menu: 6.1.0(f99eb3e0deb9fd5eb4258289317e9973)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
       ember-primitives: file:ember-primitives(5c0eaebf1b4b32661be1beb69576d86a)
       ember-resources: 7.0.7(2935cfb77147881c8250be8c1bb7d0d1)
@@ -11351,8 +11336,6 @@ snapshots:
 
   ember-cli-get-component-path-option@1.0.0: {}
 
-  ember-cli-is-package-missing@1.0.0: {}
-
   ember-cli-normalize-entity-name@1.0.0:
     dependencies:
       silent-error: 1.1.1
@@ -11442,30 +11425,30 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  ember-gesture-modifiers@6.1.0(27df71c7a625996bcf2ef19af182a2ce):
+  ember-gesture-modifiers@6.1.0(b3308737fb0c0c38e0c6422436071d39):
     dependencies:
       '@embroider/addon-shim': 1.10.2
       decorator-transforms: 2.3.2(@babel/core@7.29.0)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
-      ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-source: 7.1.0(@glimmer/component@2.1.1)
     optionalDependencies:
       '@ember/test-helpers': 5.4.2(c8332dc3f90c0e60eb130a3a85f980b9)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
 
-  ember-load-initializers@3.0.1(6d319b1a0d9582607008b9b09e953766):
+  ember-load-initializers@3.0.1(b44793b7d4517f1faf6dca9cfb99f5ed):
     dependencies:
-      ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
+      ember-source: 7.1.0(@glimmer/component@2.1.1)
 
-  ember-mobile-menu@6.1.0(c0798c5eb304914fe7bcdcc185f995aa):
+  ember-mobile-menu@6.1.0(f99eb3e0deb9fd5eb4258289317e9973):
     dependencies:
       '@ember/test-waiters': 4.1.1(c8332dc3f90c0e60eb130a3a85f980b9)
       '@embroider/addon-shim': 1.10.2
       '@glimmer/component': 2.1.1
       decorator-transforms: 2.3.2(@babel/core@7.29.0)
       ember-concurrency: 5.2.0(c8332dc3f90c0e60eb130a3a85f980b9)
-      ember-gesture-modifiers: 6.1.0(27df71c7a625996bcf2ef19af182a2ce)
+      ember-gesture-modifiers: 6.1.0(b3308737fb0c0c38e0c6422436071d39)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
       ember-primitives: file:ember-primitives(5c0eaebf1b4b32661be1beb69576d86a)
       tracked-built-ins: 4.1.2(@babel/core@7.29.0)
@@ -11575,7 +11558,7 @@ snapshots:
 
   ember-router-generator@2.0.0:
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@babel/traverse': 7.29.0
       recast: 0.18.10
     transitivePeerDependencies:
@@ -11608,35 +11591,28 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5):
+  ember-source@7.1.0(@glimmer/component@2.1.1):
     dependencies:
       '@babel/core': 7.29.0
-      '@ember/edition-utils': 1.2.0
-      '@embroider/addon-shim': 1.10.2
+      '@embroider/addon-shim': 1.10.3
       '@glimmer/component': 2.1.1
       '@simple-dom/interface': 1.4.0
       backburner.js: 2.8.0
       broccoli-file-creator: 2.1.1
-      broccoli-funnel: 3.0.8
-      broccoli-merge-trees: 4.2.0
       chalk: 4.1.2
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-cli-get-component-path-option: 1.0.0
-      ember-cli-is-package-missing: 1.0.0
       ember-cli-normalize-entity-name: 1.0.0
       ember-cli-path-utils: 1.0.0
       ember-cli-string-utils: 1.1.0
       ember-cli-typescript-blueprint-polyfill: 0.1.0
-      ember-cli-version-checker: 5.1.2
       ember-router-generator: 2.0.0
       inflection: 2.0.1
       route-recognizer: 0.3.4
-      router_js: 8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5)
-      semver: 7.7.4
+      semver: 7.8.5
       silent-error: 1.1.1
       simple-html-tokenizer: 0.5.11
     transitivePeerDependencies:
-      - rsvp
       - supports-color
 
   ember-strict-application-resolver@0.1.1(@babel/core@7.29.0):
@@ -13999,7 +13975,7 @@ snapshots:
 
   npm-install-checks@7.1.2:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   npm-normalize-package-bin@4.0.0: {}
 
@@ -14007,7 +13983,7 @@ snapshots:
     dependencies:
       hosted-git-info: 8.1.0
       proc-log: 5.0.0
-      semver: 7.7.4
+      semver: 7.8.5
       validate-npm-package-name: 6.0.2
 
   npm-pick-manifest@10.0.0:
@@ -14015,7 +13991,7 @@ snapshots:
       npm-install-checks: 7.1.2
       npm-normalize-package-bin: 4.0.0
       npm-package-arg: 12.0.2
-      semver: 7.7.4
+      semver: 7.8.5
 
   npm-run-path@4.0.1:
     dependencies:
@@ -14179,7 +14155,7 @@ snapshots:
       ky: 1.14.3
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.7.4
+      semver: 7.8.5
 
   package-manager-detector@1.6.0: {}
 
@@ -14862,12 +14838,6 @@ snapshots:
       path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
-
-  router_js@8.0.6(route-recognizer@0.3.4)(rsvp@4.8.5):
-    dependencies:
-      '@glimmer/env': 0.1.7
-      route-recognizer: 0.3.4
-      rsvp: 4.8.5
 
   rrweb-cssom@0.7.1: {}
 
@@ -15670,7 +15640,7 @@ snapshots:
 
   typescript-auto-import-cache@0.3.6:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.5
 
   typescript-eslint@8.59.0(d09d4941bb723599cbd96b45e680dbf8):
     dependencies:

--- a/test-app/babel.config.mjs
+++ b/test-app/babel.config.mjs
@@ -16,7 +16,6 @@ export default {
     [
       "babel-plugin-ember-template-compilation",
       {
-        compilerPath: "ember-source/ember-template-compiler/index.js",
         enableLegacyModules: [
           "ember-cli-htmlbars",
           "ember-cli-htmlbars-inline-precompile",

--- a/test-app/babel.config.mjs
+++ b/test-app/babel.config.mjs
@@ -16,7 +16,7 @@ export default {
     [
       "babel-plugin-ember-template-compilation",
       {
-        compilerPath: "ember-source/dist/ember-template-compiler.js",
+        compilerPath: "ember-source/ember-template-compiler/index.js",
         enableLegacyModules: [
           "ember-cli-htmlbars",
           "ember-cli-htmlbars-inline-precompile",

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -73,7 +73,7 @@
     "ember-page-title": "^9.0.3",
     "ember-qunit": "^9.0.4",
     "ember-resolver": "^13.1.1",
-    "ember-source": "^6.10.1",
+    "ember-source": "^7.1.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^7.9.3",
     "eslint": "^9.39.2",

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -686,5 +686,54 @@ module('Rendering | <Resizable>', function (hooks) {
         [51, 49]
       );
     });
+
+    test('drags past a limit do not re-report unchanged sizes', async function (assert) {
+      const onLayoutChange = () => assert.step('layout-changed');
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable @onLayoutChange={{onLayoutChange}}>
+              <Panel @minSize={{20}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.verifySteps(['layout-changed'], 'initial layout');
+
+      await triggerEvent('[data-test-handle]', 'pointerdown', {
+        button: 0,
+        pointerId: 1,
+        clientX: 250,
+        clientY: 0,
+      });
+      await triggerEvent('[data-test-handle]', 'pointermove', {
+        pointerId: 1,
+        clientX: -1000,
+        clientY: 0,
+      });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '20');
+      assert.verifySteps(['layout-changed'], 'hitting the limit is reported once');
+
+      // further movement past the limit changes nothing
+      await triggerEvent('[data-test-handle]', 'pointermove', {
+        pointerId: 1,
+        clientX: -2000,
+        clientY: 0,
+      });
+      await triggerEvent('[data-test-handle]', 'pointermove', {
+        pointerId: 1,
+        clientX: -3000,
+        clientY: 0,
+      });
+      await triggerEvent('[data-test-handle]', 'pointerup', { pointerId: 1 });
+
+      assert.verifySteps([], 'no re-reports while pinned at the limit');
+    });
   });
 });

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -605,6 +605,151 @@ module('Rendering | <Resizable>', function (hooks) {
   });
 
   module('mutation efficiency', function () {
+    /**
+     * Collects every mutation on the given elements, so tests can
+     * assert that uninvolved panels are never touched.
+     */
+    function recordMutations(selectors: string[], options?: MutationObserverInit) {
+      const records: string[] = [];
+      const observer = new MutationObserver((mutations) => {
+        for (const mutation of mutations) {
+          records.push(`${mutation.type}:${mutation.attributeName ?? ''}`);
+        }
+      });
+
+      for (const selector of selectors) {
+        const element = document.querySelector(selector);
+
+        if (!element) throw new Error(`Could not find ${selector}`);
+
+        observer.observe(element, options ?? { attributes: true, childList: true, subtree: true });
+      }
+
+      return {
+        stop() {
+          const pending = observer.takeRecords();
+
+          for (const mutation of pending) {
+            records.push(`${mutation.type}:${mutation.attributeName ?? ''}`);
+          }
+
+          observer.disconnect();
+
+          return records;
+        },
+      };
+    }
+
+    test('panels not adjacent to the dragged handle are never touched', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel style="min-width: 200px" data-test-c>c</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const spy = recordMutations(['[data-test-c]']);
+
+      await drag('[data-test-handle]', { from: 100, to: 130 });
+      await drag('[data-test-handle]', { from: 130, to: 110 });
+
+      assert.deepEqual(spy.stop(), [], 'panel c saw zero mutations during the drags');
+    });
+
+    test('keyboard resizes do not touch non-adjacent panels', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel style="min-width: 200px" data-test-c>c</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const spy = recordMutations(['[data-test-c]']);
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight');
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight');
+
+      assert.deepEqual(spy.stop(), [], 'panel c saw zero mutations');
+    });
+
+    test('resizing a nested group does not touch the outer group', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 408px;">
+            <Resizable>
+              <Panel data-test-left>left</Panel>
+              <Handle data-test-outer-handle />
+              <Panel data-test-right>
+                <Resizable @orientation="vertical">
+                  <Panel data-test-top>top</Panel>
+                  <Handle data-test-inner-handle />
+                  <Panel data-test-bottom>bottom</Panel>
+                </Resizable>
+              </Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      // the right panel contains the inner group, so only observe its
+      // own attributes (not its subtree)
+      const spy = recordMutations(
+        ['[data-test-left]', '[data-test-right]', '[data-test-outer-handle]'],
+        {
+          attributes: true,
+        }
+      );
+
+      await drag('[data-test-inner-handle]', { from: 200, to: 150, axis: 'y' });
+
+      assert.deepEqual(spy.stop(), [], 'the outer group was never touched');
+    });
+
+    test('interactions that change nothing write nothing', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel @minSize={{20}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      // pin the boundary at panel a's minSize
+      await drag('[data-test-handle]', { from: 250, to: -1000 });
+
+      const spy = recordMutations(['[data-test-a]', '[data-test-b]']);
+
+      // Enter on a non-collapsible panel is a no-op
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
+
+      // dragging further past the limit changes nothing
+      await drag('[data-test-handle]', { from: 0, to: -500 });
+
+      assert.deepEqual(spy.stop(), [], 'no writes for no-op interactions');
+    });
+
     test('content changes inside a panel do not relayout the group', async function (assert) {
       class State {
         @tracked split = false;

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -688,6 +688,8 @@ module('Rendering | <Resizable>', function (hooks) {
         </template>
       );
 
+      const spy = recordMutations(['[data-test-a]', '[data-test-b]'], { attributes: true });
+
       state.showThird = true;
       await settled();
 
@@ -696,6 +698,8 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-c]').doesNotHaveAttribute('style');
       assert.dom('[data-test-handle]').hasAria('valuenow', '33');
       assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
+
+      assert.deepEqual(spy.stop(), [], 'existing panels saw zero attribute writes');
     });
 
     test('a resize only materializes styles for the panels that moved', async function (assert) {

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -604,6 +604,57 @@ module('Rendering | <Resizable>', function (hooks) {
     });
   });
 
+  module('mutation efficiency', function () {
+    test('content changes inside a panel do not relayout the group', async function (assert) {
+      class State {
+        @tracked split = false;
+      }
+
+      const state = new State();
+      const onOuterLayout = () => assert.step('outer-layout');
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable @onLayoutChange={{onOuterLayout}}>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel data-test-c>
+                {{#if state.split}}
+                  <Resizable @orientation="vertical">
+                    <Panel data-test-inner-a>inner a</Panel>
+                    <Handle data-test-inner-handle />
+                    <Panel data-test-inner-b>inner b</Panel>
+                  </Resizable>
+                {{else}}
+                  c
+                {{/if}}
+              </Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.verifySteps(['outer-layout'], 'initial layout');
+
+      // splitting the last panel's *content* does not change the
+      // outer group's membership
+      state.split = true;
+      await settled();
+
+      assert.dom('[data-test-inner-handle]').exists('the nested group rendered');
+      assert.verifySteps([], 'no outer relayout for a nested split');
+
+      // resizing the nested group does not affect the outer group either
+      await triggerKeyEvent('[data-test-inner-handle]', 'keydown', 'ArrowDown');
+
+      assert.verifySteps([], 'no outer relayout for a nested resize');
+    });
+  });
+
   module('@onLayoutChange', function () {
     test('reports sizes when the layout changes', async function (assert) {
       let latest: number[] = [];

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -640,6 +640,91 @@ module('Rendering | <Resizable>', function (hooks) {
       };
     }
 
+    test('an all-default group mounts without writing any styles', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel data-test-c>c</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      // equal shares are what the stylesheet already renders,
+      // so no inline styles are needed at all
+      assert.dom('[data-test-a]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-b]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-c]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+    });
+
+    test('membership changes that keep shares equal write no styles', async function (assert) {
+      class State {
+        @tracked showThird = false;
+      }
+
+      const state = new State();
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              {{#if state.showThird}}
+                <Handle data-test-handle-2 />
+                <Panel data-test-c>c</Panel>
+              {{/if}}
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      state.showThird = true;
+      await settled();
+
+      assert.dom('[data-test-a]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-b]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-c]').doesNotHaveAttribute('style');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+      assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
+    });
+
+    test('a resize only materializes styles for the panels that moved', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel data-test-c>c</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const cBefore = widthOf('[data-test-c]');
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight', { shiftKey: true });
+
+      assert.dom('[data-test-a]').hasAttribute('style');
+      assert.dom('[data-test-b]').hasAttribute('style');
+      assert.dom('[data-test-c]').doesNotHaveAttribute('style');
+      assert.strictEqual(widthOf('[data-test-c]'), cBefore, 'c still renders the same size');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '43');
+    });
+
     test('panels not adjacent to the dragged handle are never touched', async function (assert) {
       await render(
         <template>

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -1,0 +1,379 @@
+import { tracked } from '@glimmer/tracking';
+import { render, settled, triggerEvent, triggerKeyEvent } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import { Resizable } from 'ember-primitives';
+
+/**
+ * The #ember-testing container is scaled, so assertions are made in
+ * "visual" pixels (getBoundingClientRect) relative to other measurements,
+ * never against hard-coded layout sizes.
+ */
+function widthOf(selector: string): number {
+  const element = document.querySelector(selector);
+
+  if (!element) throw new Error(`Could not find ${selector}`);
+
+  return element.getBoundingClientRect().width;
+}
+
+function heightOf(selector: string): number {
+  const element = document.querySelector(selector);
+
+  if (!element) throw new Error(`Could not find ${selector}`);
+
+  return element.getBoundingClientRect().height;
+}
+
+async function drag(selector: string, options: { from: number; to: number; axis?: 'x' | 'y' }) {
+  const axis = options.axis ?? 'x';
+  const start =
+    axis === 'x' ? { clientX: options.from, clientY: 0 } : { clientX: 0, clientY: options.from };
+  const end =
+    axis === 'x' ? { clientX: options.to, clientY: 0 } : { clientX: 0, clientY: options.to };
+
+  await triggerEvent(selector, 'pointerdown', { button: 0, pointerId: 1, ...start });
+  await triggerEvent(selector, 'pointermove', { pointerId: 1, ...end });
+  await triggerEvent(selector, 'pointerup', { pointerId: 1, ...end });
+}
+
+const TOLERANCE = 3;
+
+function closeTo(actual: number, expected: number): boolean {
+  return Math.abs(actual - expected) < TOLERANCE;
+}
+
+module('Rendering | <Resizable>', function (hooks) {
+  setupRenderingTest(hooks);
+
+  module('two panels, default sizes', function (hooks) {
+    hooks.beforeEach(async function () {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+    });
+
+    test('panels split the space evenly', async function (assert) {
+      const a = widthOf('[data-test-a]');
+      const b = widthOf('[data-test-b]');
+
+      assert.ok(a > 0, `a (${a}px) is visible`);
+      assert.ok(closeTo(a, b), `a (${a}px) and b (${b}px) are the same size`);
+    });
+
+    test('the handle implements the window-splitter pattern', async function (assert) {
+      assert.dom('[data-test-handle]').hasAttribute('role', 'separator');
+      assert.dom('[data-test-handle]').hasAttribute('tabindex', '0');
+      assert.dom('[data-test-handle]').hasAria('orientation', 'vertical');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+      assert.dom('[data-test-handle]').hasAria('valuemin', '0');
+      assert.dom('[data-test-handle]').hasAria('valuemax', '100');
+
+      const controls = document.querySelector('[data-test-handle]')?.getAttribute('aria-controls');
+      const panelId = document.querySelector('[data-test-a]')?.getAttribute('id');
+
+      assert.ok(panelId, 'the panel has an id');
+      assert.strictEqual(controls, panelId, 'aria-controls references the preceding panel');
+    });
+
+    test('dragging the handle resizes both panels', async function (assert) {
+      const aBefore = widthOf('[data-test-a]');
+      const bBefore = widthOf('[data-test-b]');
+
+      await drag('[data-test-handle]', { from: 200, to: 250 });
+
+      const a = widthOf('[data-test-a]');
+      const b = widthOf('[data-test-b]');
+
+      assert.ok(closeTo(a, aBefore + 50), `a grew by 50px (${aBefore}px -> ${a}px)`);
+      assert.ok(closeTo(b, bBefore - 50), `b shrank by 50px (${bBefore}px -> ${b}px)`);
+    });
+
+    test('arrow keys resize the panels', async function (assert) {
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '51');
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowLeft');
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowLeft');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '49');
+    });
+
+    test('shift+arrow resizes in coarse steps', async function (assert) {
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight', { shiftKey: true });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '60');
+    });
+
+    test('up/down arrows do nothing in a horizontal group', async function (assert) {
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowUp');
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowDown');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+    });
+
+    test('Home and End move the boundary to the extremes', async function (assert) {
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Home');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '0');
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'End');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '100');
+    });
+  });
+
+  module('constraints', function () {
+    test('minSize and maxSize are respected while dragging', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel @minSize={{20}} @maxSize={{60}} data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const total = widthOf('[data-test-a]') + widthOf('[data-test-b]');
+
+      await drag('[data-test-handle]', { from: 300, to: -1000 });
+
+      let a = widthOf('[data-test-a]');
+
+      assert.ok(closeTo(a, total * 0.2), `a stopped at its minSize (${a}px of ${total}px)`);
+      assert.dom('[data-test-handle]').hasAria('valuenow', '20');
+
+      await drag('[data-test-handle]', { from: 0, to: 1000 });
+
+      a = widthOf('[data-test-a]');
+
+      assert.ok(closeTo(a, total * 0.6), `a stopped at its maxSize (${a}px of ${total}px)`);
+      assert.dom('[data-test-handle]').hasAria('valuenow', '60');
+    });
+
+    test('defaultSize sets the initial layout', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel @defaultSize={{30}} data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '30');
+    });
+  });
+
+  module('collapsible', function () {
+    test('Enter collapses and restores the preceding panel', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel @collapsible={{true}} data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '0');
+      assert.dom('[data-test-a]').hasAttribute('data-collapsed');
+      assert.ok(widthOf('[data-test-a]') < TOLERANCE, 'panel is visually collapsed');
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+      assert.dom('[data-test-a]').doesNotHaveAttribute('data-collapsed');
+    });
+
+    test('Enter does nothing when the panel is not collapsible', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+    });
+  });
+
+  module('vertical orientation', function () {
+    test('panels stack and resize along the y-axis', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 200px; height: 408px;">
+            <Resizable @orientation="vertical" as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('orientation', 'horizontal');
+
+      const aBefore = heightOf('[data-test-a]');
+      const bBefore = heightOf('[data-test-b]');
+
+      assert.ok(closeTo(aBefore, bBefore), `a (${aBefore}px) and b (${bBefore}px) split evenly`);
+
+      await drag('[data-test-handle]', { from: 200, to: 250, axis: 'y' });
+
+      const a = heightOf('[data-test-a]');
+
+      assert.ok(closeTo(a, aBefore + 50), `a grew by 50px (${aBefore}px -> ${a}px)`);
+    });
+  });
+
+  module('nesting', function () {
+    test('an inner group resizes independently of the outer group', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 408px;">
+            <Resizable as |outer|>
+              <outer.Panel data-test-left>left</outer.Panel>
+              <outer.Handle data-test-outer-handle />
+              <outer.Panel data-test-right>
+                <Resizable @orientation="vertical" as |inner|>
+                  <inner.Panel data-test-top>top</inner.Panel>
+                  <inner.Handle data-test-inner-handle />
+                  <inner.Panel data-test-bottom>bottom</inner.Panel>
+                </Resizable>
+              </outer.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const topBefore = heightOf('[data-test-top]');
+      const bottomBefore = heightOf('[data-test-bottom]');
+      const leftBefore = widthOf('[data-test-left]');
+
+      assert.ok(
+        closeTo(topBefore, bottomBefore),
+        `top (${topBefore}px) and bottom (${bottomBefore}px) split evenly`
+      );
+
+      await drag('[data-test-inner-handle]', { from: 200, to: 150, axis: 'y' });
+
+      const top = heightOf('[data-test-top]');
+
+      assert.ok(closeTo(top, topBefore - 50), `top shrank by 50px (${topBefore}px -> ${top}px)`);
+      assert.strictEqual(
+        widthOf('[data-test-left]'),
+        leftBefore,
+        'the outer group was not affected'
+      );
+    });
+  });
+
+  module('dynamic panels', function () {
+    test('a panel added to a full group takes an equal share', async function (assert) {
+      class State {
+        @tracked showThird = false;
+      }
+
+      const state = new State();
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+              {{#if state.showThird}}
+                <r.Handle data-test-handle-2 />
+                <r.Panel data-test-c>c</r.Panel>
+              {{/if}}
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+
+      state.showThird = true;
+      await settled();
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+      assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
+
+      const a = widthOf('[data-test-a]');
+      const c = widthOf('[data-test-c]');
+
+      assert.ok(closeTo(a, c), `a (${a}px) and c (${c}px) are the same size`);
+    });
+  });
+
+  module('@onLayoutChange', function () {
+    test('reports sizes when the layout changes', async function (assert) {
+      let latest: number[] = [];
+      const onLayoutChange = (sizes: number[]) => {
+        latest = sizes;
+        assert.step('layout-changed');
+      };
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable @onLayoutChange={{onLayoutChange}} as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.verifySteps(['layout-changed'], 'initial layout is reported');
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight');
+
+      assert.verifySteps(['layout-changed'], 'keyboard resize is reported');
+      assert.deepEqual(
+        latest.map((size) => Math.round(size)),
+        [51, 49]
+      );
+    });
+  });
+});

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -79,11 +79,26 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-handle]').hasAria('valuemin', '0');
       assert.dom('[data-test-handle]').hasAria('valuemax', '100');
 
-      const controls = document.querySelector('[data-test-handle]')?.getAttribute('aria-controls');
-      const panelId = document.querySelector('[data-test-a]')?.getAttribute('id');
+      // ids are global, so none are generated
+      assert.dom('[data-test-a]').doesNotHaveAttribute('id');
+      assert.dom('[data-test-handle]').doesNotHaveAttribute('aria-controls');
+    });
 
-      assert.ok(panelId, 'the panel has an id');
-      assert.strictEqual(controls, panelId, 'aria-controls references the preceding panel');
+    test('aria-controls references a consumer-provided panel id', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel id="my-editor" data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('controls', 'my-editor');
     });
 
     test('dragging the handle resizes both panels', async function (assert) {
@@ -143,7 +158,7 @@ module('Rendering | <Resizable>', function (hooks) {
             <Resizable>
               <Panel data-test-a>a</Panel>
               <Handle data-test-handle />
-              <Panel data-test-b>b</Panel>
+              <Panel id="panel-b" data-test-b>b</Panel>
               <Handle data-test-handle-2 />
               <Panel data-test-c>c</Panel>
             </Resizable>
@@ -153,14 +168,10 @@ module('Rendering | <Resizable>', function (hooks) {
     });
 
     test('each handle describes the panel immediately before it', async function (assert) {
-      const handle2 = document.querySelector('[data-test-handle-2]');
-      const panelB = document.querySelector('[data-test-b]');
-
-      assert.strictEqual(
-        handle2?.getAttribute('aria-controls'),
-        panelB?.getAttribute('id'),
-        'the second handle controls the middle panel'
-      );
+      assert.dom('[data-test-handle-2]').hasAria('controls', 'panel-b');
+      assert
+        .dom('[data-test-handle]')
+        .doesNotHaveAttribute('aria-controls', 'no id was provided for panel a');
     });
 
     test('dragging a handle only affects its two adjacent panels', async function (assert) {

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -501,6 +501,44 @@ module('Rendering | <Resizable>', function (hooks) {
 
       assert.ok(closeTo(a, aBefore + 50), `a grew by 50px (${aBefore}px -> ${a}px)`);
     });
+
+    test('orientation may change while rendered; panels keep their sizes', async function (assert) {
+      class State {
+        @tracked orientation: 'horizontal' | 'vertical' = 'horizontal';
+      }
+
+      const state = new State();
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 408px;">
+            <Resizable @orientation={{state.orientation}}>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'ArrowRight', { shiftKey: true });
+
+      assert.dom('[data-test-handle]').hasAria('orientation', 'vertical');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '60');
+
+      state.orientation = 'vertical';
+      await settled();
+
+      assert.dom('.ember-primitives__resizable').hasAttribute('data-orientation', 'vertical');
+      assert.dom('[data-test-handle]').hasAria('orientation', 'horizontal');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '60', 'sizes survive the flip');
+
+      const a = heightOf('[data-test-a]');
+      const b = heightOf('[data-test-b]');
+
+      assert.ok(closeTo(a / (a + b), 0.6), `a keeps its 60% share (${a}px of ${a + b}px)`);
+    });
   });
 
   module('nesting', function () {
@@ -906,6 +944,106 @@ module('Rendering | <Resizable>', function (hooks) {
       await triggerKeyEvent('[data-test-inner-handle]', 'keydown', 'ArrowDown');
 
       assert.verifySteps([], 'no outer relayout for a nested resize');
+    });
+
+    test('splitting the last panel in place: nothing outside it is touched at all', async function (assert) {
+      class State {
+        @tracked split = false;
+      }
+
+      const state = new State();
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel data-test-c>
+                {{#if state.split}}
+                  <Resizable @orientation="vertical">
+                    <Panel data-test-inner-a>inner a</Panel>
+                    <Handle data-test-inner-handle />
+                    <Panel data-test-inner-b>inner b</Panel>
+                  </Resizable>
+                {{else}}
+                  c
+                {{/if}}
+              </Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      /**
+       * The strictest form of the guarantee: the split panel only
+       * gains children -- every element that survives the split (the
+       * other panels, ALL of their contents, both handles, and the
+       * split panel's own attributes) sees zero mutation records.
+       */
+      const survivors = recordMutations([
+        '[data-test-a]',
+        '[data-test-b]',
+        '[data-test-handle]',
+        '[data-test-handle-2]',
+      ]);
+      const splitPanel = recordMutations(['[data-test-c]'], { attributes: true });
+
+      state.split = true;
+      await settled();
+
+      assert.dom('[data-test-inner-handle]').exists('the nested group rendered');
+      assert.deepEqual(survivors.stop(), [], 'surviving panels and handles saw zero mutations');
+      assert.deepEqual(splitPanel.stop(), [], 'the split panel itself only gained children');
+    });
+
+    test('replacing the last panel with a split (new elements) leaves survivors untouched', async function (assert) {
+      class State {
+        @tracked split = false;
+      }
+
+      const state = new State();
+
+      // both branches render a trailing handle + panel, but toggling
+      // replaces those elements entirely -- the shape a tree-driven
+      // {{#each}} produces when a leaf is wrapped in a nested group
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              {{#if state.split}}
+                <Handle data-test-handle-2 />
+                <Panel data-test-c>
+                  <Resizable @orientation="vertical">
+                    <Panel data-test-inner-a>inner a</Panel>
+                    <Handle data-test-inner-handle />
+                    <Panel data-test-inner-b>inner b</Panel>
+                  </Resizable>
+                </Panel>
+              {{else}}
+                <Handle data-test-handle-2 />
+                <Panel data-test-c>c</Panel>
+              {{/if}}
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const survivors = recordMutations(['[data-test-a]', '[data-test-b]', '[data-test-handle]']);
+
+      state.split = true;
+      await settled();
+
+      assert.dom('[data-test-inner-handle]').exists('the nested group rendered');
+      assert.dom('[data-test-handle-2]').hasAria('valuenow', '33', 'the new handle is wired up');
+      assert.deepEqual(survivors.stop(), [], 'surviving panels and handle saw zero mutations');
     });
   });
 

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -79,10 +79,33 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-handle]').hasAria('valuemin', '0');
       assert.dom('[data-test-handle]').hasAria('valuemax', '100');
 
-      // ids are global, so none are generated; consumers who want
-      // aria-controls can set both id and aria-controls themselves
-      assert.dom('[data-test-a]').doesNotHaveAttribute('id');
-      assert.dom('[data-test-handle]').doesNotHaveAttribute('aria-controls');
+      const panelId = document.querySelector('[data-test-a]')?.getAttribute('id');
+
+      assert.ok(
+        panelId?.startsWith('ember-primitives__resizable__panel--'),
+        `the panel has a generated id (${panelId})`
+      );
+      assert.dom('[data-test-handle]').hasAria('controls', `${panelId}`);
+    });
+
+    test('the panel id is component-owned and cannot be overridden', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable>
+              <Panel id="custom" data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const panelId = document.querySelector('[data-test-a]')?.getAttribute('id');
+
+      assert.notStrictEqual(panelId, 'custom', 'the generated id wins');
+      assert.dom('[data-test-handle]').hasAria('controls', `${panelId}`);
     });
 
     test('dragging the handle resizes both panels', async function (assert) {
@@ -152,6 +175,10 @@ module('Rendering | <Resizable>', function (hooks) {
     });
 
     test('each handle describes the panel immediately before it', async function (assert) {
+      const panelB = document.querySelector('[data-test-b]')?.getAttribute('id');
+
+      assert.ok(panelB, 'the middle panel has a generated id');
+      assert.dom('[data-test-handle-2]').hasAria('controls', `${panelB}`);
       assert.dom('[data-test-handle]').hasAria('valuenow', '33');
       assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
     });

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -79,26 +79,10 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-handle]').hasAria('valuemin', '0');
       assert.dom('[data-test-handle]').hasAria('valuemax', '100');
 
-      // ids are global, so none are generated
+      // ids are global, so none are generated; consumers who want
+      // aria-controls can set both id and aria-controls themselves
       assert.dom('[data-test-a]').doesNotHaveAttribute('id');
       assert.dom('[data-test-handle]').doesNotHaveAttribute('aria-controls');
-    });
-
-    test('aria-controls references a consumer-provided panel id', async function (assert) {
-      await render(
-        <template>
-          {{! template-lint-disable no-inline-styles }}
-          <div style="width: 508px; height: 200px;">
-            <Resizable>
-              <Panel id="my-editor" data-test-a>a</Panel>
-              <Handle data-test-handle />
-              <Panel data-test-b>b</Panel>
-            </Resizable>
-          </div>
-        </template>
-      );
-
-      assert.dom('[data-test-handle]').hasAria('controls', 'my-editor');
     });
 
     test('dragging the handle resizes both panels', async function (assert) {
@@ -158,7 +142,7 @@ module('Rendering | <Resizable>', function (hooks) {
             <Resizable>
               <Panel data-test-a>a</Panel>
               <Handle data-test-handle />
-              <Panel id="panel-b" data-test-b>b</Panel>
+              <Panel data-test-b>b</Panel>
               <Handle data-test-handle-2 />
               <Panel data-test-c>c</Panel>
             </Resizable>
@@ -168,10 +152,8 @@ module('Rendering | <Resizable>', function (hooks) {
     });
 
     test('each handle describes the panel immediately before it', async function (assert) {
-      assert.dom('[data-test-handle-2]').hasAria('controls', 'panel-b');
-      assert
-        .dom('[data-test-handle]')
-        .doesNotHaveAttribute('aria-controls', 'no id was provided for panel a');
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+      assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
     });
 
     test('dragging a handle only affects its two adjacent panels', async function (assert) {

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -134,6 +134,141 @@ module('Rendering | <Resizable>', function (hooks) {
     });
   });
 
+  module('three panels', function (hooks) {
+    hooks.beforeEach(async function () {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+              <r.Handle data-test-handle-2 />
+              <r.Panel data-test-c>c</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+    });
+
+    test('each handle describes the panel immediately before it', async function (assert) {
+      const handle2 = document.querySelector('[data-test-handle-2]');
+      const panelB = document.querySelector('[data-test-b]');
+
+      assert.strictEqual(
+        handle2?.getAttribute('aria-controls'),
+        panelB?.getAttribute('id'),
+        'the second handle controls the middle panel'
+      );
+    });
+
+    test('dragging a handle only affects its two adjacent panels', async function (assert) {
+      const aBefore = widthOf('[data-test-a]');
+      const bBefore = widthOf('[data-test-b]');
+      const cBefore = widthOf('[data-test-c]');
+
+      await drag('[data-test-handle-2]', { from: 300, to: 250 });
+
+      assert.strictEqual(widthOf('[data-test-a]'), aBefore, 'a is untouched');
+      assert.ok(closeTo(widthOf('[data-test-b]'), bBefore - 50), 'b shrank');
+      assert.ok(closeTo(widthOf('[data-test-c]'), cBefore + 50), 'c grew');
+    });
+  });
+
+  module('drag lifecycle', function () {
+    test('drag state is set while dragging and cleaned up afterwards', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerEvent('[data-test-handle]', 'pointerdown', {
+        button: 0,
+        pointerId: 1,
+        clientX: 250,
+        clientY: 0,
+      });
+
+      assert.dom('[data-test-handle]').hasAttribute('data-resizing');
+      assert.strictEqual(document.body.style.cursor, 'col-resize', 'body cursor is set');
+
+      await triggerEvent('[data-test-handle]', 'pointerup', { pointerId: 1 });
+
+      assert.dom('[data-test-handle]').doesNotHaveAttribute('data-resizing');
+      assert.strictEqual(document.body.style.cursor, '', 'body cursor is restored');
+    });
+
+    test('pointercancel also ends the drag', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerEvent('[data-test-handle]', 'pointerdown', {
+        button: 0,
+        pointerId: 1,
+        clientX: 250,
+        clientY: 0,
+      });
+      await triggerEvent('[data-test-handle]', 'pointercancel', { pointerId: 1 });
+
+      assert.dom('[data-test-handle]').doesNotHaveAttribute('data-resizing');
+      assert.strictEqual(document.body.style.cursor, '', 'body cursor is restored');
+
+      // pointermove after cancel does nothing
+      const before = widthOf('[data-test-a]');
+
+      await triggerEvent('[data-test-handle]', 'pointermove', {
+        pointerId: 1,
+        clientX: 400,
+        clientY: 0,
+      });
+
+      assert.strictEqual(widthOf('[data-test-a]'), before, 'no resize after cancel');
+    });
+
+    test('non-primary buttons do not start a drag', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerEvent('[data-test-handle]', 'pointerdown', {
+        button: 2,
+        pointerId: 1,
+        clientX: 250,
+        clientY: 0,
+      });
+
+      assert.dom('[data-test-handle]').doesNotHaveAttribute('data-resizing');
+    });
+  });
+
   module('constraints', function () {
     test('minSize and maxSize are respected while dragging', async function (assert) {
       await render(
@@ -164,6 +299,45 @@ module('Rendering | <Resizable>', function (hooks) {
 
       assert.ok(closeTo(a, total * 0.6), `a stopped at its maxSize (${a}px of ${total}px)`);
       assert.dom('[data-test-handle]').hasAria('valuenow', '60');
+    });
+
+    test('defaultSizes that do not sum to 100 are normalized', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel @defaultSize={{40}} data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel @defaultSize={{40}} data-test-b>b</r.Panel>
+              <r.Handle data-test-handle-2 />
+              <r.Panel @defaultSize={{40}} data-test-c>c</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+      assert.dom('[data-test-handle-2]').hasAria('valuenow', '33');
+    });
+
+    test('End respects the following panel’s minSize', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel @minSize={{30}} data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'End');
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '70');
     });
 
     test('defaultSize sets the initial layout', async function (assert) {
@@ -208,6 +382,47 @@ module('Rendering | <Resizable>', function (hooks) {
       await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
 
       assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+      assert.dom('[data-test-a]').doesNotHaveAttribute('data-collapsed');
+    });
+
+    test('dragging far past the minSize collapses; a small overshoot holds at minSize', async function (assert) {
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel @collapsible={{true}} @minSize={{20}} data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      const total = widthOf('[data-test-a]') + widthOf('[data-test-b]');
+
+      // a small overshoot past minSize holds at minSize (20%)
+      await drag('[data-test-handle]', { from: total / 2, to: total * 0.15 });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '20');
+      assert.dom('[data-test-a]').doesNotHaveAttribute('data-collapsed');
+
+      // dragging well past half the minSize snaps closed
+      await drag('[data-test-handle]', { from: total * 0.2, to: 0 });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '0');
+      assert.dom('[data-test-a]').hasAttribute('data-collapsed');
+
+      // dragging further closed keeps it collapsed (no snap back open)
+      await drag('[data-test-handle]', { from: 0, to: -50 });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '0');
+      assert.dom('[data-test-a]').hasAttribute('data-collapsed');
+
+      // dragging back open past the minSize expands again
+      await drag('[data-test-handle]', { from: 0, to: total * 0.4 });
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '40');
       assert.dom('[data-test-a]').doesNotHaveAttribute('data-collapsed');
     });
 
@@ -341,6 +556,44 @@ module('Rendering | <Resizable>', function (hooks) {
       const c = widthOf('[data-test-c]');
 
       assert.ok(closeTo(a, c), `a (${a}px) and c (${c}px) are the same size`);
+    });
+
+    test('removing a panel gives its space back proportionally', async function (assert) {
+      class State {
+        @tracked showThird = true;
+      }
+
+      const state = new State();
+
+      await render(
+        <template>
+          {{! template-lint-disable no-inline-styles }}
+          <div style="width: 508px; height: 200px;">
+            <Resizable as |r|>
+              <r.Panel data-test-a>a</r.Panel>
+              <r.Handle data-test-handle />
+              <r.Panel data-test-b>b</r.Panel>
+              {{#if state.showThird}}
+                <r.Handle data-test-handle-2 />
+                <r.Panel data-test-c>c</r.Panel>
+              {{/if}}
+            </Resizable>
+          </div>
+        </template>
+      );
+
+      assert.dom('[data-test-handle]').hasAria('valuenow', '33');
+
+      state.showThird = false;
+      await settled();
+
+      assert.dom('[data-test-c]').doesNotExist();
+      assert.dom('[data-test-handle]').hasAria('valuenow', '50');
+
+      const a = widthOf('[data-test-a]');
+      const b = widthOf('[data-test-b]');
+
+      assert.ok(closeTo(a, b), `a (${a}px) and b (${b}px) split the space again`);
     });
   });
 

--- a/test-app/tests/resizable/rendering-test.gts
+++ b/test-app/tests/resizable/rendering-test.gts
@@ -3,7 +3,7 @@ import { render, settled, triggerEvent, triggerKeyEvent } from '@ember/test-help
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 
-import { Resizable } from 'ember-primitives';
+import { Resizable, ResizableHandle as Handle, ResizablePanel as Panel } from 'ember-primitives';
 
 /**
  * The #ember-testing container is scaled, so assertions are made in
@@ -53,10 +53,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -140,12 +140,12 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
-              <r.Handle data-test-handle-2 />
-              <r.Panel data-test-c>c</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel data-test-c>c</Panel>
             </Resizable>
           </div>
         </template>
@@ -182,10 +182,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -212,10 +212,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -249,10 +249,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -275,10 +275,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel @minSize={{20}} @maxSize={{60}} data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel @minSize={{20}} @maxSize={{60}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -301,17 +301,17 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-handle]').hasAria('valuenow', '60');
     });
 
-    test('defaultSizes that do not sum to 100 are normalized', async function (assert) {
+    test('sizes that do not sum to 100 are normalized', async function (assert) {
       await render(
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel @defaultSize={{40}} data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel @defaultSize={{40}} data-test-b>b</r.Panel>
-              <r.Handle data-test-handle-2 />
-              <r.Panel @defaultSize={{40}} data-test-c>c</r.Panel>
+            <Resizable>
+              <Panel @size={{40}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel @size={{40}} data-test-b>b</Panel>
+              <Handle data-test-handle-2 />
+              <Panel @size={{40}} data-test-c>c</Panel>
             </Resizable>
           </div>
         </template>
@@ -326,10 +326,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel @minSize={{30}} data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel @minSize={{30}} data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -340,15 +340,15 @@ module('Rendering | <Resizable>', function (hooks) {
       assert.dom('[data-test-handle]').hasAria('valuenow', '70');
     });
 
-    test('defaultSize sets the initial layout', async function (assert) {
+    test('size sets the initial layout', async function (assert) {
       await render(
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel @defaultSize={{30}} data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel @size={{30}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -364,10 +364,12 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel @collapsible={{true}} data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              {{! the border makes the collapsed panel measure > 0px,
+                  which must not confuse collapse-state detection }}
+              <Panel @collapsible={{true}} style="border: 2px solid" data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -377,12 +379,17 @@ module('Rendering | <Resizable>', function (hooks) {
 
       assert.dom('[data-test-handle]').hasAria('valuenow', '0');
       assert.dom('[data-test-a]').hasAttribute('data-collapsed');
-      assert.ok(widthOf('[data-test-a]') < TOLERANCE, 'panel is visually collapsed');
+      assert.ok(widthOf('[data-test-a]') < 5, 'panel is visually collapsed');
 
       await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
 
       assert.dom('[data-test-handle]').hasAria('valuenow', '50');
       assert.dom('[data-test-a]').doesNotHaveAttribute('data-collapsed');
+
+      // and again, to assure the toggle keeps working
+      await triggerKeyEvent('[data-test-handle]', 'keydown', 'Enter');
+
+      assert.dom('[data-test-a]').hasAttribute('data-collapsed');
     });
 
     test('dragging far past the minSize collapses; a small overshoot holds at minSize', async function (assert) {
@@ -390,10 +397,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel @collapsible={{true}} @minSize={{20}} data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel @collapsible={{true}} @minSize={{20}} data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -431,10 +438,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -452,10 +459,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 200px; height: 408px;">
-            <Resizable @orientation="vertical" as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable @orientation="vertical">
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>
@@ -482,16 +489,16 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 408px;">
-            <Resizable as |outer|>
-              <outer.Panel data-test-left>left</outer.Panel>
-              <outer.Handle data-test-outer-handle />
-              <outer.Panel data-test-right>
-                <Resizable @orientation="vertical" as |inner|>
-                  <inner.Panel data-test-top>top</inner.Panel>
-                  <inner.Handle data-test-inner-handle />
-                  <inner.Panel data-test-bottom>bottom</inner.Panel>
+            <Resizable>
+              <Panel data-test-left>left</Panel>
+              <Handle data-test-outer-handle />
+              <Panel data-test-right>
+                <Resizable @orientation="vertical">
+                  <Panel data-test-top>top</Panel>
+                  <Handle data-test-inner-handle />
+                  <Panel data-test-bottom>bottom</Panel>
                 </Resizable>
-              </outer.Panel>
+              </Panel>
             </Resizable>
           </div>
         </template>
@@ -531,13 +538,13 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
               {{#if state.showThird}}
-                <r.Handle data-test-handle-2 />
-                <r.Panel data-test-c>c</r.Panel>
+                <Handle data-test-handle-2 />
+                <Panel data-test-c>c</Panel>
               {{/if}}
             </Resizable>
           </div>
@@ -569,13 +576,13 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
               {{#if state.showThird}}
-                <r.Handle data-test-handle-2 />
-                <r.Panel data-test-c>c</r.Panel>
+                <Handle data-test-handle-2 />
+                <Panel data-test-c>c</Panel>
               {{/if}}
             </Resizable>
           </div>
@@ -609,10 +616,10 @@ module('Rendering | <Resizable>', function (hooks) {
         <template>
           {{! template-lint-disable no-inline-styles }}
           <div style="width: 508px; height: 200px;">
-            <Resizable @onLayoutChange={{onLayoutChange}} as |r|>
-              <r.Panel data-test-a>a</r.Panel>
-              <r.Handle data-test-handle />
-              <r.Panel data-test-b>b</r.Panel>
+            <Resizable @onLayoutChange={{onLayoutChange}}>
+              <Panel data-test-a>a</Panel>
+              <Handle data-test-handle />
+              <Panel data-test-b>b</Panel>
             </Resizable>
           </div>
         </template>


### PR DESCRIPTION
## What

A new `<Resizable>` component: a group of panels separated by draggable, keyboard-operable handles. Extracted/generalized from the editor-resize behavior in [NullVoxPopuli/limber](https://github.com/NullVoxPopuli/limber)'s REPL, redesigned as a composable primitive.

```gjs
<Resizable @orientation="horizontal" as |r|>
  <r.Panel @minSize={{20}}>left</r.Panel>
  <r.Handle aria-label="Resize" />
  <r.Panel>
    {{! panels can contain another <Resizable> — layouts nest into trees }}
  </r.Panel>
</Resizable>
```

## Design notes

- **Nestable by construction** — each group is a flat flex row/column; a panel may contain another group, so layouts form trees (i3/tmux style). The docs page demos this by implementing a mini i3wm (click to focus, split h/v, kill, drag/keyboard resize) in ~150 lines.
- **Pointer capture instead of a drag-surface overlay** — limber's implementation appends a full-viewport div during drags because iframes eat mouse events; `setPointerCapture` solves that natively (and `touch-action: none` covers touch).
- **Percentage/flex-grow sizing** — panel sizes are `flex: <percent> 1 0px`, so no measuring during render; pixels are only read at interaction time to convert pointer deltas.
- **WAI-ARIA [window splitter](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) pattern** — handles are focusable `role="separator"` with `aria-valuenow/min/max`, `aria-controls`, arrows (+`Shift` for coarse steps), `Home`/`End`, and `Enter` to collapse/restore `@collapsible` panels.
- **Tiling-WM-style layout on membership changes** — panels without a `@defaultSize` share remaining space; a panel added to a full group takes an equal `1/n` share while existing panels scale down proportionally.
- Registration/layout is deferred to `afterRender` (scheduleOnce) so tracked writes never happen mid-render.
- `@onLayoutChange` reports sizes (percent, document order) for persistence.

## Testing

- 15 rendering tests: pointer drag (incl. axis + nesting isolation), keyboard interactions, min/max clamping, collapse/restore, dynamic panel add, `@onLayoutChange`.
- The 5 failures currently on `main` in my environment (heading-level unit test, InViewport ×4) are unrelated and unchanged by this PR.
- Docs demos verified in-browser (drag, splits, kill/dissolve, focus styling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)