### PR TITLE
docs: unify install instructions across all pages via SetupInstructions `@since`

### DIFF
--- a/docs-app/app/components/setup.gts
+++ b/docs-app/app/components/setup.gts
@@ -14,10 +14,31 @@ function orDefault(name: string | undefined) {
   return name || 'ember-primitives';
 }
 
+/**
+ * ember-primitives releases were tagged `ember-primitives@<version>`
+ * up through 0.10.1, and `v<version>-<package-name>` from 0.10.2 onward.
+ */
+function isOldStyleTag(version: string) {
+  const [major = 0, minor = 0, patch = 0] = version.split('.').map(Number);
+
+  return major === 0 && (minor < 10 || (minor === 10 && patch < 2));
+}
+
+function releaseURL(name: string | undefined, version: string) {
+  const packageName = orDefault(name);
+  const tag =
+    packageName === 'ember-primitives' && isOldStyleTag(version)
+      ? `ember-primitives@${version}`
+      : `v${version}-${packageName}`;
+
+  return `https://github.com/universal-ember/ember-primitives/releases/tag/${tag}`;
+}
+
 export const SetupInstructions: TOC<{
   Args: {
     name?: string;
     src?: string;
+    since?: string;
   };
 }> = <template>
   <Tabs class="tabs not-prose" @label="Install as a library" as |Tab|>
@@ -39,6 +60,13 @@ export const SetupInstructions: TOC<{
         </Link>
       </Tab>
     </Tabs>
+  {{/if}}
+
+  {{#if @since}}
+    <p>
+      Introduced in
+      <Link href={{releaseURL @name @since}}>{{@since}}</Link>
+    </p>
   {{/if}}
 
   <style scoped>

--- a/docs-app/app/templates/3-ui/accordion.gjs.md
+++ b/docs-app/app/templates/3-ui/accordion.gjs.md
@@ -267,7 +267,7 @@ export default class ControlledAccordion extends Component {
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/accordion.gts" />
+<SetupInstructions @src="components/accordion.gts" @since="0.9.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/avatar.gjs.md
+++ b/docs-app/app/templates/3-ui/avatar.gjs.md
@@ -66,7 +66,7 @@ import { Avatar } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/avatar.gts" />
+<SetupInstructions @src="components/avatar.gts" @since="0.7.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/breadcrumb.gjs.md
+++ b/docs-app/app/templates/3-ui/breadcrumb.gjs.md
@@ -139,10 +139,8 @@ const ChevronDown = <template>
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/breadcrumb.gts" />
+<SetupInstructions @src="components/breadcrumb.gts" @since="0.51.0" />
 ```
-
-Introduced in [0.51.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.51.0-ember-primitives)
 
 ## Features
 

--- a/docs-app/app/templates/3-ui/form.gjs.md
+++ b/docs-app/app/templates/3-ui/form.gjs.md
@@ -129,7 +129,7 @@ const handleSubmit = (onChange, event) => {
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/form.gts" />
+<SetupInstructions @src="components/form.gts" @since="0.5.0" />
 ```
 
 ## Features 

--- a/docs-app/app/templates/3-ui/heading.gjs.md
+++ b/docs-app/app/templates/3-ui/heading.gjs.md
@@ -133,10 +133,8 @@ import { InViewport } from 'ember-primitives/viewport';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/heading.gts" />
+<SetupInstructions @src="components/heading.gts" @since="0.44.0" />
 ```
-
-Introduced in [0.44.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.44.0-ember-primitives)
 
 ## API Reference
 

--- a/docs-app/app/templates/3-ui/key-combo.gjs.md
+++ b/docs-app/app/templates/3-ui/key-combo.gjs.md
@@ -42,7 +42,7 @@ import { Key, KeyCombo } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/keys.gts" />
+<SetupInstructions @src="components/keys.gts" @since="0.28.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/one-time-password/otp-input.gjs.md
+++ b/docs-app/app/templates/3-ui/one-time-password/otp-input.gjs.md
@@ -49,7 +49,7 @@ const update = ({ code }) => currentCode.current = code;
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/one-time-password.gts" />
+<SetupInstructions @src="components/one-time-password.gts" @since="0.6.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/one-time-password/otp.gjs.md
+++ b/docs-app/app/templates/3-ui/one-time-password/otp.gjs.md
@@ -57,7 +57,7 @@ const handleSubmit = ({ code }) => submittedCode.current = code;
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/one-time-password.gts" />
+<SetupInstructions @src="components/one-time-password.gts" @since="0.6.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/progress.gjs.md
+++ b/docs-app/app/templates/3-ui/progress.gjs.md
@@ -140,7 +140,7 @@ const RandomProgress =
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/progress.gts" />
+<SetupInstructions @src="components/progress.gts" @since="0.3.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/rating.gjs.md
+++ b/docs-app/app/templates/3-ui/rating.gjs.md
@@ -376,7 +376,7 @@ const Star = <template>
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/rating.gts" />
+<SetupInstructions @src="components/rating.gts" @since="0.30.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/separator.gjs.md
+++ b/docs-app/app/templates/3-ui/separator.gjs.md
@@ -73,10 +73,8 @@ import { Separator } from "ember-primitives";
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/separator.gts" />
+<SetupInstructions @src="components/separator.gts" @since="0.52.0" />
 ```
-
-Introduced in [0.52.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.52.0-ember-primitives)
 
 ## What It Does
 

--- a/docs-app/app/templates/3-ui/slider.gjs.md
+++ b/docs-app/app/templates/3-ui/slider.gjs.md
@@ -884,7 +884,7 @@ const onKeydown = (commitFn) => (event) => {
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/slider.gts" />
+<SetupInstructions @src="components/slider.gts" @since="0.60.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/switch.gjs.md
+++ b/docs-app/app/templates/3-ui/switch.gjs.md
@@ -421,7 +421,7 @@ import { Shadowed } from 'ember-primitives/components/shadowed';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/switch.gts" />
+<SetupInstructions @src="components/switch.gts" @since="0.0.1" />
 ```
 
 ## Features 

--- a/docs-app/app/templates/3-ui/tabs.gjs.md
+++ b/docs-app/app/templates/3-ui/tabs.gjs.md
@@ -114,10 +114,8 @@ Because the  [tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/exampl
 ## Installation
 
 ```hbs live
-<SetupInstructions @src="components/tabs.gts" />
+<SetupInstructions @src="components/tabs.gts" @since="0.41.0" />
 ```
-
-Introduced in [0.41.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.41.0-ember-primitives)
 
 ## Anatomy
 

--- a/docs-app/app/templates/3-ui/toggle-group.gjs.md
+++ b/docs-app/app/templates/3-ui/toggle-group.gjs.md
@@ -107,7 +107,7 @@ const AlignRight = <template>
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/toggle-group.gts" />
+<SetupInstructions @src="components/toggle-group.gts" @since="0.13.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/3-ui/toggle.gjs.md
+++ b/docs-app/app/templates/3-ui/toggle.gjs.md
@@ -44,7 +44,7 @@ import { Toggle } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/toggle.gts" />
+<SetupInstructions @src="components/toggle.gts" @since="0.0.3" />
 ```
 
 ## Features 

--- a/docs-app/app/templates/3-ui/zoetrope.gjs.md
+++ b/docs-app/app/templates/3-ui/zoetrope.gjs.md
@@ -103,7 +103,7 @@ import { Zoetrope } from "ember-primitives";
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/zoetrope.ts" />
+<SetupInstructions @src="components/zoetrope.ts" @since="0.26.0" />
 ```
 
 ## Features

--- a/docs-app/app/templates/4-routing/external-link.gjs.md
+++ b/docs-app/app/templates/4-routing/external-link.gjs.md
@@ -25,5 +25,5 @@ import { ExternalLink } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/external-link.gts" />
+<SetupInstructions @src="components/external-link.gts" @since="0.0.1" />
 ```

--- a/docs-app/app/templates/4-routing/link.gjs.md
+++ b/docs-app/app/templates/4-routing/link.gjs.md
@@ -40,7 +40,7 @@ import { Link } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/link.gts" />
+<SetupInstructions @src="components/link.gts" @since="0.0.1" />
 ```
 
 ## Features

--- a/docs-app/app/templates/4-routing/proper-links.gjs.md
+++ b/docs-app/app/templates/4-routing/proper-links.gjs.md
@@ -6,7 +6,7 @@ You no longer need to use a component to have single-page-app navigation 🎉.
 ## Install
 
 ```hbs live
-<SetupInstructions @src="proper-links.ts" />
+<SetupInstructions @src="proper-links.ts" @since="0.0.1" />
 ```
 
 ## Setup

--- a/docs-app/app/templates/5-floaty-bits/anchor-to.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/anchor-to.gjs.md
@@ -15,9 +15,8 @@ See Floating UI's [documentation](https://floating-ui.com/docs/getting-started) 
 
 
 ```hbs live
-<SetupInstructions @src="floating-ui.ts" />
+<SetupInstructions @src="floating-ui.ts" @since="0.15.0" />
 ```
-
 
 ## `{{anchorTo}}`
 

--- a/docs-app/app/templates/5-floaty-bits/drawer.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/drawer.gjs.md
@@ -158,10 +158,8 @@ import { on } from '@ember/modifier';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/drawer.gts" />
+<SetupInstructions @src="components/drawer.gts" @since="0.51.0" />
 ```
-
-Introduced in [0.51.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.51.0-ember-primitives)
 
 ## Anatomy
 

--- a/docs-app/app/templates/5-floaty-bits/floating-ui.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/floating-ui.gjs.md
@@ -15,7 +15,7 @@ See Floating UI's [documentation](https://floating-ui.com/docs/getting-started) 
 
 
 ```hbs live
-<SetupInstructions @src="floating-ui.ts" />
+<SetupInstructions @src="floating-ui.ts" @since="0.15.0" />
 ```
 
 ## `<FloatingUI>`

--- a/docs-app/app/templates/5-floaty-bits/menu.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/menu.gjs.md
@@ -116,7 +116,7 @@ Keep in mind that for the modifier to do its work, your custom component must us
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/menu.gts" />
+<SetupInstructions @src="components/menu.gts" @since="0.15.0" />
 ```
 
 ## API Reference

--- a/docs-app/app/templates/5-floaty-bits/modal.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/modal.gjs.md
@@ -338,7 +338,7 @@ The scrollable element doesn't have to be the `body` either, it could be a `<div
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/dialog.gts" />
+<SetupInstructions @src="components/dialog.gts" @since="0.0.7" />
 ```
 
 ## Anatomy

--- a/docs-app/app/templates/5-floaty-bits/popover.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/popover.gjs.md
@@ -315,7 +315,7 @@ const settings = cell(false);
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/popover.gts" />
+<SetupInstructions @src="components/popover.gts" @since="0.0.1" />
 ```
 
 ## API Reference

--- a/docs-app/app/templates/5-floaty-bits/portal-targets.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/portal-targets.gjs.md
@@ -67,9 +67,8 @@ const isOpen = cell(false);
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/portal-targets.gts" />
+<SetupInstructions @src="components/portal-targets.gts" @since="0.0.1" />
 ```
-
 
 ## Anatomy
 

--- a/docs-app/app/templates/5-floaty-bits/portal.gjs.md
+++ b/docs-app/app/templates/5-floaty-bits/portal.gjs.md
@@ -263,7 +263,7 @@ import { PortalTarget } from 'ember-primitives/components/portal-targets';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/portal.gts" />
+<SetupInstructions @src="components/portal.gts" @since="0.0.4" />
 ```
 
 ## API Reference

--- a/docs-app/app/templates/6-utils/body-class.gjs.md
+++ b/docs-app/app/templates/6-utils/body-class.gjs.md
@@ -17,7 +17,7 @@ import { bodyClass } from 'ember-primitives/helpers/body-class';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="helpers/body-class.ts" />
+<SetupInstructions @src="helpers/body-class.ts" @since="0.31.0" />
 ```
 
 ## API Reference

--- a/docs-app/app/templates/6-utils/color-scheme.gjs.md
+++ b/docs-app/app/templates/6-utils/color-scheme.gjs.md
@@ -102,7 +102,7 @@ function syncBodyClass() {
 ## Install
 
 ```hbs live
-<SetupInstructions @src="color-scheme.gts" />
+<SetupInstructions @src="color-scheme.ts" @since="0.0.1" />
 ```
 
 ## API Reference

--- a/docs-app/app/templates/6-utils/createAsyncService.gjs.md
+++ b/docs-app/app/templates/6-utils/createAsyncService.gjs.md
@@ -24,12 +24,8 @@ This can be useful for importing services that may themselves import many things
 ## Install
 
 ```hbs live
-<SetupInstructions @src="service.ts" />
+<SetupInstructions @src="service.ts" @since="0.47.0" />
 ```
-
-
-Introduced in [0.47.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.47.0-ember-primitives)
-
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/createService.gjs.md
+++ b/docs-app/app/templates/6-utils/createService.gjs.md
@@ -24,12 +24,8 @@ This utility will create a _private_ service using a class definition similar to
 ## Install
 
 ```hbs live
-<SetupInstructions @src="service.ts" />
+<SetupInstructions @src="service.ts" @since="0.47.0" />
 ```
-
-
-Introduced in [0.47.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.47.0-ember-primitives)
-
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/createStore.gjs.md
+++ b/docs-app/app/templates/6-utils/createStore.gjs.md
@@ -16,11 +16,8 @@ When using `createStore` with the `owner` as the key, you effectively have lazyi
 ## Install
 
 ```hbs live
-<SetupInstructions @src="store.ts" />
+<SetupInstructions @src="store.ts" @since="0.38.0" />
 ```
-
-
-Introduced in [0.38.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.38.0-ember-primitives)
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/data-from-event.gjs.md
+++ b/docs-app/app/templates/6-utils/data-from-event.gjs.md
@@ -101,7 +101,6 @@ function handleSubmit(event) {
 <SetupInstructions @name="form-data-utils" />
 ```
 
-
 otherwise, this is included with ember-primitives when using the `<Form />` component.
 
 ## Anatomy

--- a/docs-app/app/templates/6-utils/dom-context.gjs.md
+++ b/docs-app/app/templates/6-utils/dom-context.gjs.md
@@ -7,11 +7,8 @@ Unlike event-based context systems, DOM Context follows the DOM tree synchronous
 ## Install
 
 ```hbs live
-<SetupInstructions @src="dom-context.gts" />
+<SetupInstructions @src="dom-context.gts" @since="0.40.0" />
 ```
-
-
-Introduced in [0.40.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.40.0-ember-primitives)
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/get-section-heading-level.gjs.md
+++ b/docs-app/app/templates/6-utils/get-section-heading-level.gjs.md
@@ -12,7 +12,6 @@ This enables distributed teams to correctly produce appropriate section heading 
 <SetupInstructions @name="which-heading-do-i-need" />
 ```
 
-
 ## Usage
 
 In your app, you can use any of `<section>`, `<article>`, and `<aside>` elements to denote when the [_Section Heading_][mdn-h] element should change its level.

--- a/docs-app/app/templates/6-utils/iframe.gjs.md
+++ b/docs-app/app/templates/6-utils/iframe.gjs.md
@@ -23,6 +23,6 @@ import { APIDocs } from 'kolay';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="iframe.ts" />
+<SetupInstructions @src="iframe.ts" @since="0.0.6" />
 ```
 

--- a/docs-app/app/templates/6-utils/in-head.gjs.md
+++ b/docs-app/app/templates/6-utils/in-head.gjs.md
@@ -36,6 +36,6 @@ const useBootstrap = cell(false);
 ## Install
 
 ```hbs live
-<SetupInstructions @src="head.gts" />
+<SetupInstructions @src="head.gts" @since="0.35.0" />
 ```
 

--- a/docs-app/app/templates/6-utils/in-viewport.gjs.md
+++ b/docs-app/app/templates/6-utils/in-viewport.gjs.md
@@ -7,9 +7,8 @@ This is useful for optimizing performance by not rendering expensive components 
 ## Install
 
 ```hbs live
-<SetupInstructions @src="viewport/in-viewport.gts" />
+<SetupInstructions @src="viewport/in-viewport.gts" @since="0.49.0" />
 ```
-
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/incremental-each.gjs.md
+++ b/docs-app/app/templates/6-utils/incremental-each.gjs.md
@@ -10,11 +10,8 @@ Use this for non-scrollable containers, or anywhere a virtual/windowed list does
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/incremental-each.gts" />
+<SetupInstructions @src="components/incremental-each.gts" @since="0.58.0" />
 ```
-
-Introduced in [0.58.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.58.0-ember-primitives)
-
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/load.gjs.md
+++ b/docs-app/app/templates/6-utils/load.gjs.md
@@ -9,9 +9,8 @@ This is a very tiny wrapper around reactiveweb's [`getPromiseState`](https://rea
 ## Install
 
 ```hbs live
-<SetupInstructions @src="load.gts" />
+<SetupInstructions @src="load.gts" @since="0.36.0" />
 ```
-
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/on-resize.gjs.md
+++ b/docs-app/app/templates/6-utils/on-resize.gjs.md
@@ -9,11 +9,8 @@ This utility also handles the (uncachable) ["ResizeObserver loop limit exceeded"
 ## Install
 
 ```hbs live
-<SetupInstructions @src="on-resize.ts" />
+<SetupInstructions @src="on-resize.ts" @since="0.32.0" />
 ```
-
-
-Introduced in [0.32.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.32.0-ember-primitives)
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/qp.gjs.md
+++ b/docs-app/app/templates/6-utils/qp.gjs.md
@@ -7,9 +7,8 @@ Utilities for accessing query-params without the need for creating a class-compo
 ## Install
 
 ```hbs live
-<SetupInstructions @src="qp.ts" />
+<SetupInstructions @src="qp.ts" @since="0.33.0" />
 ```
-
 
 ## API Reference
 

--- a/docs-app/app/templates/6-utils/resize-observer.gjs.md
+++ b/docs-app/app/templates/6-utils/resize-observer.gjs.md
@@ -10,11 +10,8 @@ This utility also handles the (uncatchable) ["ResizeObserver loop limit exceeded
 ## Install
 
 ```hbs live
-<SetupInstructions @src="resize-observer.ts" />
+<SetupInstructions @src="resize-observer.ts" @since="0.42.0" />
 ```
-
-
-Introduced in [0.42.0](https://github.com/universal-ember/ember-primitives/releases/tag/v0.42.0-ember-primitives)
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/scroller.gjs.md
+++ b/docs-app/app/templates/6-utils/scroller.gjs.md
@@ -68,9 +68,8 @@ const click = (methodName) => scrollers[methodName]();
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/scroller.gts" />
+<SetupInstructions @src="components/scroller.gts" @since="0.12.0" />
 ```
-
 
 ## Anatomy
 

--- a/docs-app/app/templates/6-utils/service.gjs.md
+++ b/docs-app/app/templates/6-utils/service.gjs.md
@@ -21,6 +21,6 @@ import { service } from 'ember-primitives/helpers/service';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="helpers/service.ts" />
+<SetupInstructions @src="helpers/service.ts" @since="0.0.1" />
 ```
 

--- a/docs-app/app/templates/6-utils/shadowed.gjs.md
+++ b/docs-app/app/templates/6-utils/shadowed.gjs.md
@@ -39,9 +39,8 @@ import { Shadowed } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/shadowed.gts" />
+<SetupInstructions @src="components/shadowed.gts" @since="0.0.1" />
 ```
-
 
 ## API Reference
 

--- a/docs-app/app/templates/6-utils/should-handle-link.gjs.md
+++ b/docs-app/app/templates/6-utils/should-handle-link.gjs.md
@@ -10,7 +10,6 @@ Before we pass off the the ember router to determine if a `href` link is part of
 <SetupInstructions @name="should-handle-link" />
 ```
 
-
 ## Usage 
 
 ```ts

--- a/docs-app/app/templates/6-utils/viewport.gjs.md
+++ b/docs-app/app/templates/6-utils/viewport.gjs.md
@@ -7,11 +7,8 @@ Using one `IntersectionObserver` (instead of multiple) results in dramatically b
 ## Install
 
 ```hbs live
-<SetupInstructions @src="viewport/viewport.ts" />
+<SetupInstructions @src="viewport/viewport.ts" @since="0.49.0" />
 ```
-
-
-Introduced in [0.49.0](https://github.com/universal-ember/ember-primitives/releases)
 
 ## Usage
 

--- a/docs-app/app/templates/6-utils/visually-hidden.gjs.md
+++ b/docs-app/app/templates/6-utils/visually-hidden.gjs.md
@@ -24,9 +24,8 @@ import { VisuallyHidden } from 'ember-primitives';
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/visually-hidden.gts" />
+<SetupInstructions @src="components/visually-hidden.gts" @since="0.29.0" />
 ```
-
 
 ## Features
 

--- a/docs-app/app/templates/8-layout/hero.gjs.md
+++ b/docs-app/app/templates/8-layout/hero.gjs.md
@@ -11,9 +11,8 @@ The hero pattern is for featuring large, eye-catching content, such as an image 
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/layout/hero.gts" />
+<SetupInstructions @src="components/layout/hero.gts" @since="0.22.0" />
 ```
-
 
 ## Anatomy
 

--- a/docs-app/app/templates/8-layout/resizable.gjs.md
+++ b/docs-app/app/templates/8-layout/resizable.gjs.md
@@ -968,14 +968,8 @@ const sizeOf = (group, index) => saved[group]?.[index];
 
 ## Install
 
-```bash
-pnpm add ember-primitives
-```
-
-```js
-import { Resizable, Panel, Handle } from 'ember-primitives/components/resizable';
-// or, from the barrel:
-import { Resizable, ResizablePanel, ResizableHandle } from 'ember-primitives';
+```hbs live
+<SetupInstructions @src="components/resizable.gts" @since="0.61.0" />
 ```
 
 ## Anatomy

--- a/docs-app/app/templates/8-layout/sticky-footer.gjs.md
+++ b/docs-app/app/templates/8-layout/sticky-footer.gjs.md
@@ -126,9 +126,8 @@ const removeContent = () => content.splice(-1);
 ## Install
 
 ```hbs live
-<SetupInstructions @src="components/layout/sticky-footer.gts" />
+<SetupInstructions @src="components/layout/sticky-footer.gts" @since="0.8.0" />
 ```
-
 
 ## Features
 


### PR DESCRIPTION
Unifies the Install instructions on every docs page to a single pattern, and makes the "Introduced in" note impossible to drift.

## The unified pattern

Every page that documents an installable component/utility/service now has:

```md
## Install

​```hbs live
<SetupInstructions @src="components/heading.gts" @since="0.44.0" />
​```
```

## Design decision: `@since` lives in the component

Rather than a hand-written "Introduced in [X](...)" markdown line after the fence (which a third of pages had, each slightly different, one with a broken link), `SetupInstructions` now accepts a `@since` arg and renders the "Introduced in" line itself, linking to the release. The component knows the tag-format history:

- `ember-primitives@<version>` for releases up through 0.10.1
- `v<version>-<package>` from 0.10.2 onward

so old and new versions both link to the correct release page. The 13 pages that had hand-written notes (including the heading page this pattern came from) were migrated to `@since`, so there is now exactly one way to do it.

## Version derivation

For each documented thing, the version is the earliest ember-primitives release tag containing the commit that added its source file (`git log --diff-filter=A -- ember-primitives/src/<path>` + `git tag --contains`). Files that were restructured since introduction were traced to their original paths:

- OTP: `components/one-time-password/index.gts` (0.6.0), later flattened to `one-time-password.gts`
- StickyFooter: `components/layout/sticky-footer/index.gts` (0.8.0), later flattened
- Zoetrope: `components/zoetrope/index.gts` (0.26.0), later flattened

The method was validated against the 12 pre-existing hand-written notes (all 12 matched exactly) and spot-checked against CHANGELOG.md entries (Slider 0.60.0, OTP 0.6.0, StickyFooter 0.8.0, Zoetrope 0.26.0, Accordion 0.9.0, Avatar 0.7.0). All old-style `ember-primitives@X` tags were confirmed to have GitHub release pages.

## What changed

- **50 pages** now carry `@since` (49 already used `SetupInstructions`; resizable's hand-rolled `pnpm add` + import fences were replaced with the unified block — its import example is redundant with the Anatomy section directly below)
- **13 pages** had their hand-written "Introduced in" lines migrated into `@since` (viewport's note also gains the correct release-tag link it was missing)
- **color-scheme** page's `@src` pointed at a non-existent `color-scheme.gts`; fixed to `color-scheme.ts`

## Intentionally skipped

- `1-get-started/index` keeps its plain `<SetupInstructions />` — it installs the whole library, so a component-introduction version doesn't apply
- External packages documented here get no version note, since their releases don't live in this repo: `ember-mobile-menu` (sidebar), `form-data-utils` (data-from-event), `should-handle-link`
- `which-heading-do-i-need` (get-section-heading-level) is in-repo with tags (`v0.1.0-which-heading-do-i-need`), but no GitHub releases exist for any of its tags, so a release link would 404
- Index/overview pages (accessibility, testing guides) document no installable thing and get no Install section

## Verification

- `pnpm build` (turbo, all workspace packages) passes
- `docs-app` vite build passes
- `docs-app` test suite (testem) passes
- `docs-app` lint:js / lint:hbs / lint:types / lint:prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
