### PR TITLE
Fix Deploy Preview: opt in to fork PR checkout under actions/checkout@v7

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -111,6 +111,16 @@ jobs:
         with:
           repository: ${{ needs.determinePR.outputs.repo }}
           ref: ${{ needs.determinePR.outputs.branch }}
+          # Never write the base repo's GITHUB_TOKEN into .git/config,
+          # since this job runs (potentially fork-authored) build scripts.
+          persist-credentials: false
+          # checkout@v7 refuses to check out fork PR code from workflow_run
+          # workflows unless explicitly opted in. This is the deliberate,
+          # documented (see header comment) trade-off of this trusted-workflow
+          # pattern: only this Build job touches PR code, and the deploy /
+          # comment jobs below never check out code.
+          # https://gh.io/securely-using-pull_request_target
+          allow-unsafe-pr-checkout: true
       - name: TurboRepo local server
         uses: felixmosh/turborepo-gh-artifacts@v4
         with:


### PR DESCRIPTION
## Observed failure

Every Deploy Preview run for a fork PR has failed since the `actions/checkout@v7` bump landed on `main` (e.g. runs [29719499232](https://github.com/universal-ember/ember-primitives/actions/runs/29719499232), 29718773192, 29718465925 — all fail in ~15s at the checkout step):

```
##[error]Refusing to check out fork pull request code from a 'workflow_run' workflow.
This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch
cache scope, and runner access. Fetching and executing a fork's code in that trusted
context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks
at https://gh.io/securely-using-pull_request_target and set
'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

The last successful run ([29714709768](https://github.com/universal-ember/ember-primitives/actions/runs/29714709768)) still resolved `actions/checkout@v6`, which had no such guard — confirming the v7 bump is the trigger, not a change to this workflow.

## Root cause

`actions/checkout@v7` added a safety guard: when running in a `workflow_run`-triggered workflow, it refuses to check out a `repository:`/`ref:` that resolves to fork PR code unless the step explicitly sets `allow-unsafe-pr-checkout: true`. This workflow is exactly that (deliberate, documented in its header comment) pattern: the `Build` job checks out the PR's fork branch to build the docs preview.

## Fix

On the `Build` job's checkout step (the only place in the workflow that touches PR code):

- `allow-unsafe-pr-checkout: true` — the documented opt-in; this is precisely the trusted-workflow trade-off the yml header already describes and accepts.
- `persist-credentials: false` — hardening that directly addresses the risk the new guard warns about: this job runs (potentially fork-authored) build scripts, and without this the base repo's `GITHUB_TOKEN` would sit in `.git/config` where those scripts could read it. Nothing in the Build job pushes or fetches after checkout, so nothing needs persisted credentials.

## Security model preserved

- The `Build` job gains no new secret access — it still only sees the default `GITHUB_TOKEN` it already had; the opt-in flag only acknowledges the existing, intentional behavior, and `persist-credentials: false` strictly reduces what fork code can reach.
- `DeployPreview_Docs` (Cloudflare secrets) and `PostComment` still never check out PR code — they only download the built static artifact, exactly as before.

Validated with `actionlint` (clean) and by matching the change to the exact error text; the workflow can't be exercised from a fork without this fix landing on the default branch first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)