### PR TITLE
docs-support: side-nav highlight for extension-suffixed URLs

### DIFF
--- a/packages/docs-support/src/side-nav.gts
+++ b/packages/docs-support/src/side-nav.gts
@@ -3,7 +3,7 @@ import { on } from '@ember/modifier';
 import { service } from '@ember/service';
 
 import { sentenceCase } from 'change-case';
-import { link } from 'ember-primitives/helpers';
+import { link, service as getService } from 'ember-primitives/helpers';
 import { PageNav } from 'kolay/components';
 import { getAnchor } from 'should-handle-link';
 
@@ -70,14 +70,34 @@ const asComponent = (str: string) => {
   return `<${str.split('.')[0]?.replaceAll(' ', '')} />`;
 };
 
+/**
+ * Docs pages are reachable both with and without their file extension
+ * (prose cross-links produce `/2-usage/data.md`, while the nav's own
+ * hrefs are extension-less), and collection index pages are reachable
+ * at both `/2-usage` and `/2-usage/index`. Normalize both sides before
+ * comparing, so the nav highlight survives however the reader got to
+ * the page.
+ */
+function isActivePath(currentURL: string | null | undefined, href: string) {
+  if (!currentURL) return false;
+
+  const normalize = (path: string) =>
+    (path.split('?')[0] ?? '')
+      .replace(/\.gjs\.md$|\.gjs$|\.md$/, '')
+      .replace(/\/index$/, '')
+      .replace(/\/$/, '');
+
+  return normalize(currentURL) === normalize(href);
+}
+
 const isComponents = (str: string) => str === 'components';
 
 const SectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name: string } }> =
   <template>
-    {{#let (link @href) as |l|}}
+    {{#let (link @href) (getService 'router') as |l router|}}
       <a
         href={{@href}}
-        class="section-link {{if l.isActive 'is-active'}}"
+        class="section-link {{if (isActivePath router.currentURL @href) 'is-active'}}"
         {{on "click" l.handleClick}}
         ...attributes
       >
@@ -92,10 +112,10 @@ const SectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name:
 
 const SubSectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name: string } }> =
   <template>
-    {{#let (link @href) as |l|}}
+    {{#let (link @href) (getService 'router') as |l router|}}
       <a
         href={{@href}}
-        class="subsection-link {{if l.isActive 'is-active'}}"
+        class="subsection-link {{if (isActivePath router.currentURL @href) 'is-active'}}"
         {{on "click" l.handleClick}}
         ...attributes
       >

--- a/packages/docs-support/src/side-nav.gts
+++ b/packages/docs-support/src/side-nav.gts
@@ -94,7 +94,7 @@ const isComponents = (str: string) => str === 'components';
 
 const SectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name: string } }> =
   <template>
-    {{#let (link @href) (getService 'router') as |l router|}}
+    {{#let (link @href) (getService "router") as |l router|}}
       <a
         href={{@href}}
         class="section-link {{if (isActivePath router.currentURL @href) 'is-active'}}"
@@ -112,7 +112,7 @@ const SectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name:
 
 const SubSectionLink: TOC<{ Element: HTMLAnchorElement; Args: { href: string; name: string } }> =
   <template>
-    {{#let (link @href) (getService 'router') as |l router|}}
+    {{#let (link @href) (getService "router") as |l router|}}
       <a
         href={{@href}}
         class="subsection-link {{if (isActivePath router.currentURL @href) 'is-active'}}"


### PR DESCRIPTION
Docs pages are reachable both extension-less (the side-nav's own hrefs) and with `.md`/`.gjs.md` suffixes — every prose cross-link produces the suffixed form — plus collection indexes at both `/section` and `/section/index`. The `link` helper's `isActive` compares URLs exactly, so as soon as a reader follows any cross-link, the nav highlight silently disappears.

This normalizes both sides (`.gjs.md`/`.gjs`/`.md` suffixes, `/index`, trailing slash, query strings) before comparing, in `SectionLink`/`SubSectionLink`.

Verified against the docs-app dev server: visiting `/3-ui/switch.md` directly now highlights "Switch" in both the desktop and mobile navs; in-app navigation behavior is unchanged. The normalization also passed a table-driven check during development:

```
/2-usage/data.md      ~ /2-usage/data        ✓
/1-get-started/index  ~ /1-get-started       ✓
/3-ui/switch.gjs.md   ~ /3-ui/switch         ✓
(+ query strings, trailing slashes, non-matches)
```

Found while building out universal-ember/form's docs (universal-ember/form#23) — this fixes the same behavior for the primitives, table, and form docs sites alike.

🤖 Generated with [Claude Code](https://claude.com/claude-code)