### PR TITLE
docs-app: preview the unreleased kolay (docs() + apiDocs() plugin split)

### DIFF
--- a/docs-app/app/templates/3-ui/one-time-password/otp-input.json
+++ b/docs-app/app/templates/3-ui/one-time-password/otp-input.json
@@ -1,3 +1,3 @@
 {
-  "componentName": "OTPInput"
+  "title": "OTPInput"
 }

--- a/docs-app/app/templates/3-ui/one-time-password/otp.json
+++ b/docs-app/app/templates/3-ui/one-time-password/otp.json
@@ -1,3 +1,3 @@
 {
-  "componentName": "OTP"
+  "title": "OTP"
 }

--- a/docs-app/vite.config.mjs
+++ b/docs-app/vite.config.mjs
@@ -1,7 +1,7 @@
 import { ember, extensions } from "@embroider/vite";
 
 import { babel } from "@rollup/plugin-babel";
-import { kolay } from "kolay/vite";
+import { apiDocs, docs } from "kolay/vite";
 import { defineConfig } from "vite";
 import { scopedCSS } from "ember-scoped-css/vite";
 import rehypeShiki from "@shikijs/rehype";
@@ -11,8 +11,8 @@ export default defineConfig(async (/* { mode } */) => {
     plugins: [
       scopedCSS(),
       ember(),
-      kolay({
-        packages: ["ember-primitives", "which-heading-do-i-need"],
+      // no group: the docs are the co-located pages in app/templates
+      docs({
         rehypePlugins: [
           [
             rehypeShiki,
@@ -38,6 +38,7 @@ export default defineConfig(async (/* { mode } */) => {
           import { Callout } from '@universal-ember/docs-support';
         `,
       }),
+      apiDocs(["ember-primitives", "which-heading-do-i-need"]),
       babel({
         babelHelpers: "runtime",
         extensions,

--- a/docs-app/vite.config.mjs
+++ b/docs-app/vite.config.mjs
@@ -43,6 +43,18 @@ export default defineConfig(async (/* { mode } */) => {
         extensions,
       }),
     ],
+    build: {
+      /**
+       * Vite's default cssTarget predates light-dark(), so lightningcss
+       * rewrites it into var(--lightningcss-light/dark) space toggles whose
+       * :root definitions don't survive chunking — the declarations then
+       * fail at computed-value time (kolay's typedoc colors, for example).
+       * The rewrite would also key theming off prefers-color-scheme,
+       * ignoring our color-scheme toggle. These targets support
+       * light-dark() natively.
+       */
+      cssTarget: ["chrome123", "firefox120", "safari17.5"],
+    },
     optimizeDeps: {
       exclude: [
         // a wasm-providing dependency

--- a/docs-app/vite.config.mjs
+++ b/docs-app/vite.config.mjs
@@ -11,7 +11,6 @@ export default defineConfig(async (/* { mode } */) => {
     plugins: [
       scopedCSS(),
       ember(),
-      // no group: the docs are the co-located pages in app/templates
       docs({
         rehypePlugins: [
           [

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
       "ember-primitives": "workspace:^",
       "ember-repl": "^8.0.0",
       "ember-source": "^7.1.0",
+      "kolay": "github:universal-ember/kolay#dist",
       "reactiveweb": "^1.9.1",
       "tracked-toolbox": "^3.0.0"
     },

--- a/packages/docs-support/src/site-css/prose.css
+++ b/packages/docs-support/src/site-css/prose.css
@@ -210,8 +210,9 @@
   color: #f8fafc;
 }
 
-/* Pre (code blocks) */
-.prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+/* Pre (code blocks) — kolay's typedoc renderer writes names (@arg, <:block>)
+   as <pre class="typedoc__name">, which are inline code, not code blocks */
+.prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *, .typedoc__name)) {
   color: var(--prose-pre-code);
   background-color: var(--prose-pre-bg);
   overflow-x: auto;
@@ -229,7 +230,7 @@
 
 :is(html[style*="color-scheme: dark"])
   .prose
-  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *, .typedoc__name)) {
   background-color: rgb(30 41 59 / 0.6);
   box-shadow: none;
   outline: 1px solid rgb(203 213 225 / 0.1);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   ember-primitives: workspace:^
   ember-repl: ^8.0.0
   ember-source: ^7.1.0
+  kolay: github:universal-ember/kolay#dist
   reactiveweb: ^1.9.1
   tracked-toolbox: ^3.0.0
 
@@ -105,8 +106,8 @@ importers:
         specifier: ^2.2.1
         version: 2.2.2(highlight.js@11.11.1)
       kolay:
-        specifier: ^5.1.2
-        version: 5.2.0(a417d88aa35fbfb0591a793939686c8f)
+        specifier: github:universal-ember/kolay#dist
+        version: https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765(a417d88aa35fbfb0591a793939686c8f)
       limber-ui:
         specifier: ^4.1.1
         version: 4.2.1(c8332dc3f90c0e60eb130a3a85f980b9)
@@ -476,8 +477,8 @@ importers:
         specifier: ^4.0.2
         version: 4.1.1
       kolay:
-        specifier: ^5.1.2
-        version: 5.2.0(a417d88aa35fbfb0591a793939686c8f)
+        specifier: github:universal-ember/kolay#dist
+        version: https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765(a417d88aa35fbfb0591a793939686c8f)
       package-up:
         specifier: ^5.0.0
         version: 5.0.0
@@ -5287,8 +5288,9 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  kolay@5.2.0:
-    resolution: {integrity: sha512-0ExGdvBmlmitKeL8nAit4GCKZO5T+Ya1FqIOI1c/Qnv64wDLoz0LBFye9iXDH8fTM/BhbT+uw2qadhjsiuxtWQ==}
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765:
+    resolution: {gitHosted: true, integrity: sha512-hxBAMq65JGlqmcswJrl6T4RnZ0fn4QGpryyaoLTMmwexb0Y6U4Gx16B0htLbyhJvNnChCYJs0uE8DJ8MPzdj8w==, tarball: https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765}
+    version: 5.4.0
     engines: {node: '>= 18'}
 
   ky@1.14.3:
@@ -10128,7 +10130,7 @@ snapshots:
       ember-primitives: file:ember-primitives(5c0eaebf1b4b32661be1beb69576d86a)
       ember-resources: 7.0.7(2935cfb77147881c8250be8c1bb7d0d1)
       inter-ui: 4.1.1
-      kolay: 5.2.0(a417d88aa35fbfb0591a793939686c8f)
+      kolay: https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765(a417d88aa35fbfb0591a793939686c8f)
       package-up: 5.0.0
       read-package-up: 12.0.0
       should-handle-link: 1.3.0
@@ -13196,7 +13198,7 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  kolay@5.2.0(a417d88aa35fbfb0591a793939686c8f):
+  kolay@https://codeload.github.com/universal-ember/kolay/tar.gz/f4a21ade2abe9a0bcdeffa921940664f05774765(a417d88aa35fbfb0591a793939686c8f):
     dependencies:
       '@ember/test-waiters': 4.1.1(c8332dc3f90c0e60eb130a3a85f980b9)
       '@embroider/addon-shim': 1.10.2
@@ -13204,7 +13206,7 @@ snapshots:
       '@glint/template': 1.7.7
       change-case: 5.4.4
       common-tags: 1.8.2
-      content-tag: 4.1.1
+      content-tag: 4.2.0
       decorator-transforms: 2.3.2(@babel/core@7.29.0)
       ember-modifier: 4.3.0(@babel/core@7.29.0)
       ember-primitives: file:ember-primitives(5c0eaebf1b4b32661be1beb69576d86a)


### PR DESCRIPTION
kolay's next release reworks the vite plugin API (universal-ember/kolay#323; the changes are on kolay's `main` but unreleased). This PR lets us preview those changes on the ember-primitives docs before the release.

## How the preview works

kolay pushes its built package contents to its `dist` branch on every commit to `main` (via `push-dist.yml`). A root `pnpm.overrides` entry resolves `kolay` to `github:universal-ember/kolay#dist` for the whole workspace, so `docs-app` and `@universal-ember/docs-support` keep their declared semver ranges. When kolay releases, we drop the override and bump the ranges instead.

## Migration changes

- **vite.config.mjs**: the combined `kolay()` plugin is split — `docs({ rehypePlugins, scope })` (no group: serves the co-located `app/templates` pages) + `apiDocs(["ember-primitives", "which-heading-do-i-need"])`.
- **page json configs**: `componentName` → `title` for the OTP/OTPInput pages. `docs-support`'s `side-nav` already falls back to `title`, and the rendered nav text is identical; the `componentName` branch is kept so docs-support still works with kolay 5.x.
- **unchanged**: the top-level `addRoutes(this)` still serves co-located pages from the root URL space (URLs stay the same), and `setupKolay()`'s `topLevelScope`/`modules` options are untouched.

## Verification

- `docs-app` `vite build --mode development` + testem suite passes locally (the pages test walks every docs page in all three color schemes)
- `lint:types` passes in `docs-app` and `packages/docs-support`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
