### PR TITLE
fix(docs-support): stop double-prefixing SideNav links with rootURL

### DIFF
--- a/packages/docs-support/src/side-nav.gts
+++ b/packages/docs-support/src/side-nav.gts
@@ -1,6 +1,5 @@
 import Component from '@glimmer/component';
 import { on } from '@ember/modifier';
-import { service } from '@ember/service';
 
 import { sentenceCase } from 'change-case';
 import { link } from 'ember-primitives/helpers';
@@ -8,7 +7,6 @@ import { PageNav } from 'kolay/components';
 import { getAnchor } from 'should-handle-link';
 
 import type { TOC } from '@ember/component/template-only';
-import type RouterService from '@ember/routing/router-service';
 import type { Page } from 'kolay';
 
 type CustomPage = Page & {
@@ -25,18 +23,6 @@ function fixWords(text: string) {
       return text;
   }
 }
-
-const joinUrl = (...strs: string[]) => {
-  const prefix = strs[0]?.startsWith('/') ? '/' : '';
-
-  return (
-    prefix +
-    strs
-      .map((s) => s.replace(/^\//, '').replace(/\/$/, ''))
-      .filter((x) => !!x)
-      .join('/')
-  );
-};
 
 /**
  * Converts 1-2-hyphenated-thing
@@ -114,12 +100,6 @@ export class SideNav extends Component<{
     onClick?: () => void;
   };
 }> {
-  @service('router') declare router: RouterService;
-
-  get rootUrl() {
-    return this.router.rootURL;
-  }
-
   closeNav = (event: Event) => {
     if (!getAnchor(event)) return;
 
@@ -143,7 +123,7 @@ export class SideNav extends Component<{
       <PageNav aria-label="Main Navigation">
         <:page as |x|>
           <SubSectionLink
-            @href={{joinUrl this.rootUrl x.page.path}}
+            @href={{x.page.path}}
             @name={{nameFor x.page}}
             {{on "click" this.closeNav}}
           />
@@ -152,7 +132,7 @@ export class SideNav extends Component<{
         <:collection as |x|>
           {{#if x.index}}
             <SectionLink
-              @href={{joinUrl this.rootUrl x.index.page.path}}
+              @href={{x.index.page.path}}
               @name={{titleize x.collection.name}}
               {{on "click" this.closeNav}}
             />


### PR DESCRIPTION
## Summary

`kolay`'s `page.path` / `collection.index.page.path` already include the
app's `rootURL` (see `router.hrefFor`'s doc comment: "Includes the rootURL,
like `page.path`" in `src/browser/services/docs.ts`). `SideNav` was
additionally wrapping those paths in `joinUrl(this.rootUrl, path)`, which
prefixed `rootURL` a second time.

For apps whose `rootURL` is `/` this is a harmless no-op (`joinUrl` dedupes
adjacent slashes), which is why it wasn't caught before. But for any app
deployed under a subpath (`rootURL` other than `/`), every link rendered by
`SideNav` points at a URL like `/subpath/subpath/some-page`, which doesn't
resolve to a real route and breaks in-app navigation from the side nav.

## Changes

- `SideNav` now passes `x.page.path` / `x.index.page.path` straight through
  as `@href`, without the extra `joinUrl(this.rootUrl, ...)` wrapping.
- Removed the now-unused `joinUrl` helper, `router` service injection, and
  `rootUrl` getter.

We're carrying this as a `pnpm patch` in downstream consumer
[carbon-components-ember](https://github.com/carbon-design-system/carbon-components-ember)
where `rootURL` isn't `/`; happy to adjust the fix if there's a reason the
double-prefixing was intentional.

## Test plan

- [x] `pnpm lint:hbs` / `pnpm lint:prettier` pass on the changed file
- [x] Manually verified in the downstream consumer's docs app that side nav
      links resolve correctly once the double `rootURL` prefix is removed