### PR TITLE
Fix CI: stop running `pnpm install` next to builds

### DIFF
--- a/docs-app/package.json
+++ b/docs-app/package.json
@@ -24,7 +24,6 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "_syncPnpm": "pnpm install --frozen-lockfile",
     "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -22,7 +22,6 @@
     "format": "prettier --write .",
     "start": "pnpm vite",
     "dev": "vite",
-    "_syncPnpm": "pnpm install --frozen-lockfile",
     "sync": "echo 'pnpm is syncing injected deps. (this is configured in .npmrc)'",
     "test:ember": "vite build --mode development && testem ci --port 0"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -52,7 +52,7 @@
       "persistent": true
     },
     "start": {
-      "dependsOn": ["_syncPnpm", "^build"],
+      "dependsOn": ["^build"],
       "outputs": [],
       "cache": false,
       "persistent": true
@@ -68,7 +68,7 @@
     // development
     "build:dev": {
       "outputs": ["dist/**", "dist-types/**", "declarations/**"],
-      "dependsOn": ["_syncPnpm"]
+      "dependsOn": ["^build"]
     },
     "pack": {
       "outputs": ["*.tgz"],
@@ -77,27 +77,19 @@
     // production
     "build": {
       "outputs": ["dist/**", "dist-types/**", "declarations/**", "docs.json"],
-      "dependsOn": ["_syncPnpm", "//#sync"]
+      "dependsOn": ["^build", "//#sync"]
     },
     "//#sync": {},
-    "_syncPnpm": {
-      "dependsOn": ["^build"],
-      "cache": false
-    },
     "test": {
       "outputs": [],
-      "dependsOn": ["_syncPnpm", "^build"]
+      "dependsOn": ["^build"]
     },
     // Apps will have test:ember and test:browserstack
     // They are separate so that they can cache independently
     // and provide more variability than just "test"
     "test:ember": {
-      "env": [
-        "CI_BROWSER",
-        "EMBER_TRY_CURRENT_SCENARIO",
-        "EMBROIDER_TEST_SETUP_OPTIONS"
-      ],
-      "dependsOn": ["_syncPnpm", "^build"]
+      "env": ["CI_BROWSER", "EMBER_TRY_CURRENT_SCENARIO", "EMBROIDER_TEST_SETUP_OPTIONS"],
+      "dependsOn": ["^build"]
     },
     // All scenarios
     "test:scenarios": {


### PR DESCRIPTION
Every PR run has been red since at least Aug 9 — including renovate lockfile-only PRs ([example](https://github.com/universal-ember/ember-primitives/actions/runs/31337363458)) — with `Setup` dying at:

```
ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL  Command failed with EACCES: ember-tsc --declaration --declarationDir declarations
spawn ember-tsc EACCES
Failed: @universal-ember/docs-support#build
```

## What it actually was

`_syncPnpm` was `pnpm install --frozen-lockfile`, declared as a turbo task with `dependsOn: ["^build"]`. Both `test-app#_syncPnpm` and `@universal-ember/docs-support#build` are unblocked by `ember-primitives#build`, so **turbo ran an install concurrently with a build**.

An install rewrites every package's `node_modules/.bin`. Rollup's `declarations` plugin spawns `ember-tsc` out of exactly that directory. If the spawn lands mid-rewrite, the shim is either gone or written-but-not-yet-`chmod`'d — and spawning a non-executable file is `EACCES`.

Nothing about the code was involved, which is why lockfile-only PRs failed identically.

## Measured, not guessed

Polling `packages/docs-support/node_modules/.bin/ember-tsc` during a full `pnpm build --force`, while separately recording the window in which docs-support's own `ember-tsc` process was alive:

| | shim unusable, **inside that spawn window** |
| :-- | --: |
| `main` | **27** samples |
| this branch | **0** samples |

Isolated, a single `pnpm install --frozen-lockfile` in `test-app` leaves the docs-support shim missing or `-rw-rw-r--` for a good fraction of its run — 178 unusable samples in one install.

Note the race is probabilistic: `pnpm build` often *passes* locally on `main`. The CI runner loses it reliably.

## The install was redundant

`.npmrc` already has `sync-injected-deps-after-scripts[]=build`, so pnpm re-syncs injected workspace deps itself after each package's `build` script. Verified directly: added a marker to `ember-primitives/src`, ran `pnpm --filter ember-primitives build`, and found the marker in `test-app`'s injected copy — with no install of any kind. `test-app`'s own `sync` script already says as much in its echo.

That sync runs *inside* the owning package's `pnpm run build`, which turbo waits on, so it cannot overlap a sibling's build. The remaining rewrites all land outside the spawn window — that is what the 0 above measures.

`_syncPnpm` was also how `build`, `build:dev`, `test`, `test:ember`, and `start` inherited `^build`. That is now declared directly on each, which is what they meant.

## Checked locally

- `pnpm build` green, five consecutive `--force` runs
- `pnpm lint` — 24/24 tasks
- `pnpm turbo test:ember --filter test-app` — green apart from four `<InViewport />` failures that are pre-existing on `main` here (IntersectionObserver under headless Chrome); they are unrelated to this change, and CI has never gotten far enough to say whether they fail on a runner too

The workflow's own `pnpm i -f` steps are untouched: they run sequentially, before the build, and race nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)